### PR TITLE
Add auto fixture to use tmp db per session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         language_version: python3
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-asyncmock; python_version < '3.8'
+mock; python_version < '3.8'
 pytest
 black
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+asyncmock; python_version < '3.8'
 pytest
 black
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3 >= 1.21.7
-prefect>=2.0a9
+prefect>=2.0b3
 anyio >= 3.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ def temp_db_path(tmpdir_factory):
     tmp_db_path = tmpdir_factory.mktemp("db")
     db_file_path = tmp_db_path.join("orion.db")
     yield str(db_file_path)
-    tmp_db_path.
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import pytest
+from prefect.utilities.testing import prefect_test_harness
 
 from prefect_aws import AwsCredentials
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_db():
+    with prefect_test_harness():
+        yield
 
 
 @pytest.fixture
@@ -10,18 +17,3 @@ def aws_credentials():
         aws_secret_access_key="secret_access_key",
         region_name="us-east-1",
     )
-
-
-@pytest.fixture(scope="session")
-def temp_db_path(tmpdir_factory):
-    tmp_db_path = tmpdir_factory.mktemp("db")
-    db_file_path = tmp_db_path.join("orion.db")
-    return str(db_file_path)
-
-
-@pytest.fixture(autouse=True)
-def init_prefect_db(monkeypatch, temp_db_path):
-    monkeypatch.setenv(
-        "PREFECT_ORION_DATABASE_CONNECTION_URL", f"sqlite+aiosqlite://{temp_db_path}"
-    )
-    monkeypatch.setenv("PREFECT_API_URL", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-
+import os
 from prefect_aws import AwsCredentials
 
 
@@ -10,3 +10,19 @@ def aws_credentials():
         aws_secret_access_key="secret_access_key",
         region_name="us-east-1",
     )
+
+
+@pytest.fixture(scope="session")
+def temp_db_path(tmpdir_factory):
+    tmp_db_path = tmpdir_factory.mktemp("db")
+    db_file_path = tmp_db_path.join("orion.db")
+    yield str(db_file_path)
+    tmp_db_path.
+
+
+@pytest.fixture(autouse=True)
+def init_prefect_db(monkeypatch, temp_db_path):
+    monkeypatch.setenv("PREFECT_ORION_DATABASE_CONNECTION_URL",f"sqlite+aiosqlite://{temp_db_path}")
+    yield
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,4 @@ def init_prefect_db(monkeypatch, temp_db_path):
     monkeypatch.setenv(
         "PREFECT_ORION_DATABASE_CONNECTION_URL", f"sqlite+aiosqlite://{temp_db_path}"
     )
+    monkeypatch.setenv("PREFECT_API_URL", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,11 @@ def aws_credentials():
 def temp_db_path(tmpdir_factory):
     tmp_db_path = tmpdir_factory.mktemp("db")
     db_file_path = tmp_db_path.join("orion.db")
-    yield str(db_file_path)
+    return str(db_file_path)
 
 
 @pytest.fixture(autouse=True)
 def init_prefect_db(monkeypatch, temp_db_path):
-    monkeypatch.setenv("PREFECT_ORION_DATABASE_CONNECTION_URL",f"sqlite+aiosqlite://{temp_db_path}")
-    yield
-
-
+    monkeypatch.setenv(
+        "PREFECT_ORION_DATABASE_CONNECTION_URL", f"sqlite+aiosqlite://{temp_db_path}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import os
+
 from prefect_aws import AwsCredentials
 
 

--- a/tests/test_secrets_manager.py
+++ b/tests/test_secrets_manager.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import datetime, timedelta
 
 import boto3
 import pytest
@@ -156,9 +156,10 @@ async def test_delete_secret(
         result = flow_state.result().result()
         assert result.get("Name") == secret_under_test["secret_name"]
         deletion_date = result.get("DeletionDate")
+
         if not force_delete_without_recovery:
             assert deletion_date.date() == (
-                date.today() + timedelta(days=recovery_window_in_days)
+                datetime.utcnow().date() + timedelta(days=recovery_window_in_days)
             )
         else:
-            assert deletion_date.date() == date.today()
+            assert deletion_date.date() == datetime.utcnow().date()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
This is a new fixture that creates a tmp per pytest run.  I had on going dev with another version of Orion and all the pytest are failing because of that. That fixture allow to have a tmp db of orion everytime

I expect we could extract this fixture to a package pytest-prefect and can be shared with another prefect project in the future

## Relevant Issue(s)
This is an enhancement to the current pytest capability