### PR TITLE
Upgrade black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         language_version: python3
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Upgrades `black` in `pre-commit` to 22.3.0 to resolve CI errors