### PR TITLE
add missing AwsCredentials in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You will need to obtain AWS credentials in order to use these tasks. Refer to th
 ### Write and run a flow with prefect-aws tasks
 ```python
 from prefect import flow
+from prefect_aws import AwsCredentials
 from prefect_aws.s3 import s3_upload
 
 @flow


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds missing AwsCredentials import in the first readme example. 

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->