### PR TITLE
Add `ECSTask` infrastructure block

### DIFF
--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -1,0 +1,264 @@
+import copy
+import warnings
+from typing import Dict, List, Literal, Optional, Tuple, Union
+
+import yaml
+from prefect.docker import get_prefect_image_name
+from prefect.infrastructure.base import Infrastructure, InfrastructureResult
+from pydantic import BaseModel, Field, root_validator
+
+from prefect_aws import AwsCredentials
+
+
+class ECSTaskResult(InfrastructureResult):
+    """The result of a run of an ECS task"""
+
+
+ECS_TASK_RUN_CONTAINER_NAME = "prefect"
+
+
+class ECSTask(Infrastructure):
+    """ """
+
+    type: Literal["ecs-task"] = "ecs-task"
+
+    aws_credentials: AwsCredentials = Field(default_factory=AwsCredentials)
+
+    # Task definition settings
+    task_definition_arn: Optional[str] = None
+    task_definition: Optional[dict] = None
+    image: str = Field(default_factory=get_prefect_image_name)
+
+    # TODO: Determine if these should be included
+    # task_family: Optional[str] = None
+    # network_mode: Optional[str] = None
+
+    # Task run settings
+    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL"]] = None
+    cluster: Optional[str] = None
+    env: Dict[str, str] = Field(default_factory=dict)
+    cpu: Union[int, str] = None
+    memory: Union[int, str] = None
+    task_role_arn: str = None
+    execution_role_arn: str = None
+    capacity_provider_strategy: List[dict] = Field(default_factory=list)
+
+    @root_validator
+    def set_default_launch_type(cls, values):
+        """
+        To use FARGATE_SPOT, the launch type must be left empty. If a launch type is
+        not providing and the user isn't using FARGATE_SPOT, the launch type defaults
+        to FARGATE.
+        """
+        strategies = values.get("capacity_provider_strategy")
+        launch_type = values.get("launch_type")
+        using_fargate_spot = False
+
+        if strategies:
+            providers = {strategy.get("capacityProvider") for strategy in strategies}
+            using_fargate_spot = "FARGATE_SPOT" in providers
+
+        FARGATE_SPOT_WARNING = (
+            "'FARGATE_SPOT' capacity provider found in 'capacity_provider_strategy'"
+            "but 'launch_type' is set to {launch_type!r}. "
+            "Set the launch type to `None` to allow 'FARGATE_SPOT' to be used."
+        )
+        if using_fargate_spot and launch_type:
+            warnings.warn(FARGATE_SPOT_WARNING.format(launch_type), stacklevel=3)
+
+        if not launch_type and not using_fargate_spot:
+            values["launch_type"] = "FARGATE"
+
+        return values
+
+    # @root_validator
+    # def set_default_network_mode(cls, values):
+    #     """
+    #     If a task definition arn is not linked or the network mode is not set in the
+    #     given task definition the network mode should default to 'awsvpc'
+    #     """
+    #     if not values.get("task_definition_arn") and not values.get(
+    #         "task_definition", {}
+    #     ).get("networkMode"):
+    #         values.setdefault("network_mode", "awsvpc")
+    #     return values
+
+    # @root_validator
+    # def set_default_task_family(cls, values):
+    #     """
+    #     If a task definition arn is not linked or the family is not set in the
+    #     given task definition the family should default to 'prefect'
+    #     """
+    #     if not values.get("task_definition_arn") and not values.get(
+    #         "task_definition", {}
+    #     ).get("family"):
+    #         values.setdefault("family", "prefect")
+    #     return values
+
+    async def run(self):
+        ecs_client = self.get_ecs_client()
+
+        task_definition = (
+            self.retrieve_task_definition(ecs_client, self.task_definition_arn)
+            if self.task_definition_arn
+            else self.task_definition
+        ) or {}
+        task_definition_arn = task_definition.get("taskDefinitionArn", None)
+
+        prepared_task_definition = self.prepare_task_definition(task_definition)
+
+        # We must register the task definition if the arn is null or changes were made
+        if prepared_task_definition != task_definition or not task_definition_arn:
+            task_definition_arn = self.register_task_definition(
+                ecs_client, prepared_task_definition
+            )
+
+        task_run = self.prepare_task_run(prepared_task_definition, task_definition_arn)
+        return ecs_client.run_task(**task_run)
+
+    def preview(self) -> str:
+        preview = ""
+
+        task_definition_arn = self.task_definition_arn or "<registered-at-runtime>"
+
+        if self.task_definition or not self.task_definition_arn:
+            task_definition = self.prepare_task_definition(self.task_definition or {})
+            preview += "----- Task definition -----\n"
+            preview += yaml.dump(task_definition)
+            preview += "\n"
+
+        task_run = self.prepare_task_run(task_definition or {}, task_definition_arn)
+        preview += "----- Task run -----\n"
+        preview += yaml.dump(task_run)
+
+        return preview
+
+    def get_ecs_client(self):
+        return self.aws_credentials.get_boto3_session().client("ecs")
+
+    def retrieve_task_definition(self, ecs_client, task_definition_arn: str):
+        response = ecs_client.describe_task_definition(
+            taskDefinition=task_definition_arn
+        )
+        return response["taskDefinition"]
+
+    def register_task_definition(self, ecs_client, task_definition: dict) -> str:
+        # TODO: Consider including a global cache for this task definition since
+        #       registration of task definitions is frequently rate limited
+        response = ecs_client.register_task_definition(**task_definition)
+        return response["taskDefinition"]["taskDefinitionArn"]
+
+    def get_prefect_container_definition(
+        self, container_definitions: List[dict]
+    ) -> Optional[dict]:
+        for container in container_definitions:
+            if container.get("name") == ECS_TASK_RUN_CONTAINER_NAME:
+                return container
+        return None
+
+    def prepare_task_definition(self, task_definition: dict) -> dict:
+        # Prepare the task definition by inferring any defaults and merging overrides
+        task_definition = copy.deepcopy(task_definition)
+
+        # Configure the Prefect runtime container
+        task_definition.setdefault(
+            "containerDefinitions", [{"name": ECS_TASK_RUN_CONTAINER_NAME}]
+        )
+        container = self.get_prefect_container_definition(
+            task_definition["containerDefinitions"]
+        )
+        container["image"] = self.image
+
+        # task_definition.setdefault("networkMode", "awsvpc")
+        task_definition.setdefault("family", "prefect")
+
+        # CPU and memory are required in some cases, retrieve the value to use
+        cpu = self.cpu or task_definition.get("cpu") or 1024
+        memory = self.memory or task_definition.get("memory") or 2048
+
+        if self.launch_type == "FARGATE":
+            # Task level memory and cpu are required when using fargate
+            task_definition["cpu"] = str(cpu)
+            task_definition["memory"] = str(memory)
+        elif self.launch_type == "EC2":
+            # Container level memory and cpu are required when using ec2
+            container.setdefault("cpu", int(cpu))
+            container.setdefault("memory", int(memory))
+
+        return task_definition
+
+    def prepare_task_run_overrides(self) -> dict:
+        overrides = {
+            "containerOverrides": [
+                {
+                    "name": ECS_TASK_RUN_CONTAINER_NAME,
+                    "environment": [
+                        {"name": key, "value": value} for key, value in self.env.items()
+                    ],
+                }
+            ],
+        }
+
+        if self.command:
+            overrides["containerOverrides"][0]["command"] = self.command
+
+        if self.execution_role_arn:
+            overrides["executionRoleArn"] = self.execution_role_arn
+
+        if self.task_role_arn:
+            overrides["taskRoleArn"] = self.task_role_arn
+
+        if self.cluster:
+            overrides["cluster"] = self.cluster
+
+        if self.memory:
+            overrides["memory"] = str(self.memory)
+
+        if self.cpu:
+            overrides["cpu"] = str(self.cpu)
+
+        return overrides
+
+    def infer_network_configuration(self, network_mode: Optional[str]) -> dict:
+        if network_mode == "awsvpc":
+            # Retrieve the default VPC
+            ec2_client = self.aws_credentials.get_boto3_session().client("ec2")
+            vpcs = ec2_client.describe_vpcs(
+                Filters=[{"Name": "isDefault", "Values": ["true"]}]
+            )["Vpcs"]
+            if vpcs:
+                vpc_id = vpcs[0]["VpcId"]
+                subnets = ec2_client.describe_subnets(
+                    Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+                )["Subnets"]
+                if subnets:
+                    config = {
+                        "awsvpcConfiguration": {
+                            "subnets": [s["SubnetId"] for s in subnets],
+                            "assignPublicIp": "ENABLED",
+                        }
+                    }
+                    self.logger.debug(
+                        "ECSTask %r: Using networkConfiguration=%r", self.name, config
+                    )
+                    return config
+
+        return {}
+
+    def prepare_task_run(self, task_definition: dict, task_definition_arn: str) -> dict:
+        task_run = {
+            "overrides": self.prepare_task_run_overrides(),
+            "capacityProviderStrategy": self.capacity_provider_strategy,
+            "networkConfiguration": self.infer_network_configuration(
+                task_definition.get("networkMode")
+            ),
+            "tags": [
+                {"name": key, "value": value} for key, value in self.labels.items()
+            ],
+            "taskDefinition": task_definition_arn,
+        }
+
+        if self.launch_type:
+            task_run["launchType"] = self.launch_type
+
+        return task_run

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -19,7 +19,9 @@ ECS_TASK_RUN_CONTAINER_NAME = "prefect"
 
 
 class ECSTask(Infrastructure):
-    """ """
+    """
+    Run a command as an ECS task
+    """
 
     type: Literal["ecs-task"] = "ecs-task"
 
@@ -29,10 +31,6 @@ class ECSTask(Infrastructure):
     task_definition_arn: Optional[str] = None
     task_definition: Optional[dict] = None
     image: str = Field(default_factory=get_prefect_image_name)
-
-    # TODO: Determine if these should be included
-    # task_family: Optional[str] = None
-    # network_mode: Optional[str] = None
 
     # Task run settings
     launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL"]] = None
@@ -49,7 +47,7 @@ class ECSTask(Infrastructure):
     def set_default_launch_type(cls, values):
         """
         To use FARGATE_SPOT, the launch type must be left empty. If a launch type is
-        not providing and the user isn't using FARGATE_SPOT, the launch type defaults
+        not provided and the user isn't using FARGATE_SPOT, the launch type defaults
         to FARGATE.
         """
         strategies = values.get("capacity_provider_strategy")
@@ -73,70 +71,29 @@ class ECSTask(Infrastructure):
 
         return values
 
-    # @root_validator
-    # def set_default_network_mode(cls, values):
-    #     """
-    #     If a task definition arn is not linked or the network mode is not set in the
-    #     given task definition the network mode should default to 'awsvpc' when using
-    #     the FARGATE launch mode
-    #     """
-    #     if (
-    #         not values.get("task_definition_arn")
-    #         and not (values.get("task_definition") or {}).get("networkMode")
-    #         and values.get("launch_type") == "FARGATE"
-    #     ):
-    #         values.setdefault("network_mode", "awsvpc")
-    #     return values
-
-    # @root_validator
-    # def check_network_mode_fargate_compatibility(cls, values):
-    #     """
-    #     If using the 'FARGATE' launch mode, the network mode must be 'awsvpc'
-    #     """
-    #     network_mode = (values.get("task_definition") or {}).get("networkMode")
-    #     launch_type = values.get("launch_type")
-    #     if network_mode and network_mode != "awsvpc" and launch_type == "FARGATE":
-    #         raise ValueError(
-    #             f"Network mode {network_mode!r} is not compatible with launch type 'FARGATE'. "
-    #             "'awsvpc' must be used instead."
-    #         )
-    #     return values
-
-    # @root_validator
-    # def set_default_task_family(cls, values):
-    #     """
-    #     If a task definition arn is not linked or the family is not set in the
-    #     given task definition the family should default to 'prefect'
-    #     """
-    #     if not values.get("task_definition_arn") and not values.get(
-    #         "task_definition", {}
-    #     ).get("family"):
-    #         values.setdefault("family", "prefect")
-    #     return values
-
     @sync_compatible
     async def run(self):
-        ecs_client = self.get_ecs_client()
+        ecs_client = self._get_ecs_client()
 
         requested_task_definition = (
-            self.retrieve_task_definition(ecs_client, self.task_definition_arn)
+            self._retrieve_task_definition(ecs_client, self.task_definition_arn)
             if self.task_definition_arn
             else self.task_definition
         ) or {}
         task_definition_arn = requested_task_definition.get("taskDefinitionArn", None)
 
-        task_definition = self.prepare_task_definition(requested_task_definition)
+        task_definition = self._prepare_task_definition(requested_task_definition)
 
         # We must register the task definition if the arn is null or changes were made
         if task_definition != requested_task_definition or not task_definition_arn:
             self.logger.info(f"ECSTask {self.name!r}: Registering task definition...")
             self.logger.debug("\n" + yaml.dump(task_definition))
-            task_definition_arn = self.register_task_definition(
+            task_definition_arn = self._register_task_definition(
                 ecs_client, task_definition
             )
 
         if task_definition.get("networkMode") == "awsvpc":
-            network_config = self.load_vpc_network_config(self.vpc_id)
+            network_config = self._load_vpc_network_config(self.vpc_id)
         else:
             network_config = None
 
@@ -147,30 +104,15 @@ class ECSTask(Infrastructure):
         try:
             result = ecs_client.run_task(**task_run)
         except Exception as exc:
-            self.report_task_run_failure(task_run, exc)
-
-    def report_task_run_failure(self, task_run, exc: Exception) -> None:
-        """
-        Wrap common AWS task run failures with nicer user-facing messages.
-        """
-        # AWS generates exception types at runtime so they must be captured a bit
-        # differently than normal.
-        if "ClusterNotFoundException" in str(exc):
-            cluster = task_run.get("cluster", "default")
-            raise RuntimeError(
-                f"Failed to run ECS task, cluster {cluster!r} not found. "
-                "Confirm that the cluster is configured in your region."
-            ) from exc
-        else:
-            raise
+            self._report_task_run_failure(task_run, exc)
 
     def preview(self) -> str:
         preview = ""
 
-        task_definition_arn = self.task_definition_arn or "<registered-at-runtime>"
+        task_definition_arn = self.task_definition_arn or "<registered at runtime>"
 
         if self.task_definition or not self.task_definition_arn:
-            task_definition = self.prepare_task_definition(self.task_definition or {})
+            task_definition = self._prepare_task_definition(self.task_definition or {})
             preview += "----- Task definition -----\n"
             preview += yaml.dump(task_definition)
             preview += "\n"
@@ -187,10 +129,25 @@ class ECSTask(Infrastructure):
 
         return preview
 
-    def get_ecs_client(self):
+    def _report_task_run_failure(self, task_run, exc: Exception) -> None:
+        """
+        Wrap common AWS task run failures with nicer user-facing messages.
+        """
+        # AWS generates exception types at runtime so they must be captured a bit
+        # differently than normal.
+        if "ClusterNotFoundException" in str(exc):
+            cluster = task_run.get("cluster", "default")
+            raise RuntimeError(
+                f"Failed to run ECS task, cluster {cluster!r} not found. "
+                "Confirm that the cluster is configured in your region."
+            ) from exc
+        else:
+            raise
+
+    def _get_ecs_client(self):
         return self.aws_credentials.get_boto3_session().client("ecs")
 
-    def retrieve_task_definition(self, ecs_client, task_definition_arn: str):
+    def _retrieve_task_definition(self, ecs_client, task_definition_arn: str):
 
         self.logger.info(
             f"ECSTask {self.name!r}: Retrieving task definition {task_definition_arn!r}..."
@@ -200,13 +157,13 @@ class ECSTask(Infrastructure):
         )
         return response["taskDefinition"]
 
-    def register_task_definition(self, ecs_client, task_definition: dict) -> str:
+    def _register_task_definition(self, ecs_client, task_definition: dict) -> str:
         # TODO: Consider including a global cache for this task definition since
         #       registration of task definitions is frequently rate limited
-        response = ecs_client.register_task_definition(**task_definition)
+        response = ecs_client._register_task_definition(**task_definition)
         return response["taskDefinition"]["taskDefinitionArn"]
 
-    def get_prefect_container_definition(
+    def _get_prefect_container_definition(
         self, container_definitions: List[dict]
     ) -> Optional[dict]:
         for container in container_definitions:
@@ -214,7 +171,7 @@ class ECSTask(Infrastructure):
                 return container
         return None
 
-    def prepare_task_definition(self, task_definition: dict) -> dict:
+    def _prepare_task_definition(self, task_definition: dict) -> dict:
         # Prepare the task definition by inferring any defaults and merging overrides
         task_definition = copy.deepcopy(task_definition)
 
@@ -222,12 +179,11 @@ class ECSTask(Infrastructure):
         task_definition.setdefault(
             "containerDefinitions", [{"name": ECS_TASK_RUN_CONTAINER_NAME}]
         )
-        container = self.get_prefect_container_definition(
+        container = self._get_prefect_container_definition(
             task_definition["containerDefinitions"]
         )
         container["image"] = self.image
 
-        # task_definition.setdefault("networkMode", "awsvpc")
         task_definition.setdefault("family", "prefect")
 
         # CPU and memory are required in some cases, retrieve the value to use
@@ -248,7 +204,14 @@ class ECSTask(Infrastructure):
 
             # Only the 'awsvpc' network mode is supported when using FARGATE
             # However, we will not enforce that here if the user has set it
-            task_definition.setdefault("networkMode", "awsvpc")
+            network_mode = task_definition.setdefault("networkMode", "awsvpc")
+
+            if network_mode != "awsvpc":
+                warnings.warn(
+                    f"Found network mode {network_mode!r} which is not compatible with "
+                    "launch type 'FARGATE'. Either use the 'EC2' launch type or the "
+                    "'awsvpc' network mode."
+                )
 
         elif self.launch_type == "EC2":
             # Container level memory and cpu are required when using ec2
@@ -257,7 +220,7 @@ class ECSTask(Infrastructure):
 
         return task_definition
 
-    def prepare_task_run_overrides(self) -> dict:
+    def _prepare_task_run_overrides(self) -> dict:
         overrides = {
             "containerOverrides": [
                 {
@@ -289,7 +252,7 @@ class ECSTask(Infrastructure):
 
         return overrides
 
-    def load_vpc_network_config(self, vpc_id: Optional[str]) -> dict:
+    def _load_vpc_network_config(self, vpc_id: Optional[str]) -> dict:
 
         ec2_client = self.aws_credentials.get_boto3_session().client("ec2")
         vpc_message = "the default VPC" if not vpc_id else f"VPC with ID {vpc_id}"
@@ -329,11 +292,11 @@ class ECSTask(Infrastructure):
             }
         }
 
-    def prepare_task_run(
+    def _prepare_task_run(
         self, network_config: Optional[dict], task_definition_arn: str
     ) -> dict:
         task_run = {
-            "overrides": self.prepare_task_run_overrides(),
+            "overrides": self._prepare_task_run_overrides(),
             "capacityProviderStrategy": self.capacity_provider_strategy,
             "tags": [
                 {"name": key, "value": value} for key, value in self.labels.items()

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -1,12 +1,12 @@
 import copy
 import warnings
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import yaml
 from prefect.docker import get_prefect_image_name
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.utilities.asyncutils import sync_compatible
-from pydantic import BaseModel, Field, root_validator
+from pydantic import Field, root_validator
 
 from prefect_aws import AwsCredentials
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -1,3 +1,36 @@
+"""
+Examples:
+
+    Run a task using ECS Fargate
+    >>> ECSTask(command=["echo", "hello world"]).run()
+
+    Run a task using ECS Fargate with a spot container instance
+    >>> ECSTask(command=["echo", "hello world"], launch_type="FARGATE_SPOT").run()
+
+    Run a task using ECS with an EC2 container instance
+    >>> ECSTask(command=["echo", "hello world"], launch_type="EC2").run()
+
+    Run a task on a specific VPC using ECS Fargate
+    >>> ECSTask(command=["echo", "hello world"], vpc_id="vpc-01abcdf123456789a").run()
+
+    Run a task and stream the container's output to the local terminal
+    >>> ECSTask(command=["echo", "hello world"], stream_output=True)
+
+    Run a task using an existing task definition as a base
+    >>> ECSTask(command=["echo", "hello world"], task_definition_arn="arn:aws:ecs:...")
+
+    Run a task with a specific image
+    >>> ECSTask(command=["echo", "hello world"], image="alpine:latest")
+
+    Run a task with custom memory and CPU requirements
+    >>> ECSTask(command=["echo", "hello world"], memory=4096, cpu=2048)
+
+    Run a task with custom environment variables
+    >>> ECSTask(command=["echo", "hello $PLANET"], env={"PLANET": "earth"})
+
+    Run a task in a specific ECS cluster
+    >>> ECSTask(command=["echo", "hello world"], cluster="my-cluster-name")
+"""
 import copy
 import time
 import warnings
@@ -32,47 +65,47 @@ class ECSTask(Infrastructure):
     task_definition_arn: Optional[str] = None
     task_definition: Optional[dict] = None
     image: str = Field(default_factory=get_prefect_image_name)
+
     family_prefix: str = "prefect"
 
     # Mixed task definition / run settings
     cpu: Union[int, str] = None
     memory: Union[int, str] = None
+    execution_role_arn: str = None
+    configure_cloudwatch_logs: bool = None
+    stream_output: bool = False
 
     # Task run settings
-    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL"]] = None
+    launch_type: Optional[
+        Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
+    ] = "FARGATE"
     vpc_id: Optional[str] = None
     cluster: Optional[str] = None
     env: Dict[str, str] = Field(default_factory=dict)
     task_role_arn: str = None
-    execution_role_arn: str = None
-    capacity_provider_strategy: List[dict] = Field(default_factory=list)
+
+    @root_validator(pre=True)
+    def set_default_configure_cloudwatch_logs(cls, values):
+        """
+        Streaming output generally requires CloudWatch logs to be configured.
+
+        To avoid entangled arguments in the simple case, `configure_cloudwatch_logs`
+        defaults to matching the value of `stream_output`.
+        """
+        configure_cloudwatch_logs = values.get("configure_cloudwatch_logs")
+        if configure_cloudwatch_logs is None:
+            values["configure_cloudwatch_logs"] = values.get("stream_output")
+        return values
 
     @root_validator
-    def set_default_launch_type(cls, values):
-        """
-        To use FARGATE_SPOT, the launch type must be left empty. If a launch type is
-        not provided and the user isn't using FARGATE_SPOT, the launch type defaults
-        to FARGATE.
-        """
-        strategies = values.get("capacity_provider_strategy")
-        launch_type = values.get("launch_type")
-        using_fargate_spot = False
-
-        if strategies:
-            providers = {strategy.get("capacityProvider") for strategy in strategies}
-            using_fargate_spot = "FARGATE_SPOT" in providers
-
-        FARGATE_SPOT_WARNING = (
-            "'FARGATE_SPOT' capacity provider found in 'capacity_provider_strategy'"
-            "but 'launch_type' is set to {launch_type!r}. "
-            "Set the launch type to `None` to allow 'FARGATE_SPOT' to be used."
-        )
-        if using_fargate_spot and launch_type:
-            warnings.warn(FARGATE_SPOT_WARNING.format(launch_type), stacklevel=3)
-
-        if not launch_type and not using_fargate_spot:
-            values["launch_type"] = "FARGATE"
-
+    def configure_cloudwatch_logs_requires_execution_role_arn(cls, values):
+        if values.get("configure_cloudwatch_logs") and not values.get(
+            "execution_role_arn"
+        ):
+            raise ValueError(
+                "An `execution_role_arn` must be provided to use "
+                "`configure_cloudwatch_logs` or `stream_logs`."
+            )
         return values
 
     @sync_compatible
@@ -80,7 +113,8 @@ class ECSTask(Infrastructure):
         """
         Run the configured task on ECS.
         """
-        ecs_client = self._get_ecs_client()
+        boto_session = self.aws_credentials.get_boto3_session()
+        ecs_client = boto_session.client("ecs")
 
         requested_task_definition = (
             self._retrieve_task_definition(ecs_client, self.task_definition_arn)
@@ -89,35 +123,56 @@ class ECSTask(Infrastructure):
         ) or {}
         task_definition_arn = requested_task_definition.get("taskDefinitionArn", None)
 
-        task_definition = self._prepare_task_definition(requested_task_definition)
+        task_definition = self._prepare_task_definition(
+            requested_task_definition, region=ecs_client.meta.region_name
+        )
 
         # We must register the task definition if the arn is null or changes were made
         if task_definition != requested_task_definition or not task_definition_arn:
             self.logger.info(f"ECSTask {self.name!r}: Registering task definition...")
-            self.logger.debug("\n" + yaml.dump(task_definition))
+            self.logger.debug("Task definition payload\n" + yaml.dump(task_definition))
             task_definition_arn = self._register_task_definition(
                 ecs_client, task_definition
             )
 
         if task_definition.get("networkMode") == "awsvpc":
-            network_config = self._load_vpc_network_config(self.vpc_id)
+            network_config = self._load_vpc_network_config(self.vpc_id, boto_session)
         else:
             network_config = None
 
-        task_run = self._prepare_task_run(network_config, task_definition_arn)
+        task_run = self._prepare_task_run(
+            network_config=network_config,
+            task_definition_arn=task_definition_arn,
+        )
         self.logger.info(f"ECSTask {self.name!r}: Creating ECS task run...")
-        self.logger.debug("\n" + yaml.dump(task_run))
+        self.logger.debug("Task run payload\n" + yaml.dump(task_run))
 
         try:
             task_arn = ecs_client.run_task(**task_run)["tasks"][0]["taskArn"]
         except Exception as exc:
             self._report_task_run_creation_failure(task_run, exc)
 
-        task = self._watch_task(task_arn, ecs_client)
+        task = self._watch_task(task_arn, task_definition, ecs_client, boto_session)
+
+        status_code = self._get_prefect_container(task["containers"]).get(
+            "exitCode", -1
+        )
+        if status_code == -1:
+            self.logger.error(
+                f"ECSTask {self.name!r}: Task exited without reporting a container "
+                "exit status."
+            )
+        elif status_code == 0:
+            self.logger.info(f"ECSTask {self.name!r}: Container exited successfully.")
+        else:
+            self.logger.warning(
+                f"ECSTask {self.name!r}: Container exited with non-zero exit code "
+                f"{status_code}."
+            )
 
         return ECSTaskResult(
             identifier=task_arn,
-            status_code=self._get_prefect_container(task["containers"])["exitCode"],
+            status_code=status_code,
         )
 
     def preview(self) -> str:
@@ -129,7 +184,11 @@ class ECSTask(Infrastructure):
         task_definition_arn = self.task_definition_arn or "<registered at runtime>"
 
         if self.task_definition or not self.task_definition_arn:
-            task_definition = self._prepare_task_definition(self.task_definition or {})
+            task_definition = self._prepare_task_definition(
+                self.task_definition or {},
+                region=self.aws_credentials.region_name
+                or "<loaded from client at runtime>",
+            )
             preview += "---\n# Task definition\n"
             preview += yaml.dump(task_definition)
             preview += "\n"
@@ -160,16 +219,46 @@ class ECSTask(Infrastructure):
                 f"Failed to run ECS task, cluster {cluster!r} not found. "
                 "Confirm that the cluster is configured in your region."
             ) from exc
+        elif "No Container Instances" in str(exc) and self.launch_type == "EC2":
+            cluster = task_run.get("cluster", "default")
+            raise RuntimeError(
+                f"Failed to run ECS task, cluster {cluster!r} does not appear to "
+                "have any container instances associated with it. Confirm that you "
+                "have EC2 container instances available."
+            ) from exc
         else:
             raise
 
-    def _watch_task(self, task_arn: str, ecs_client, poll_interval: int = 5):
+    def _watch_task(
+        self,
+        task_arn: str,
+        task_definition: dict,
+        ecs_client,
+        boto_session,
+        poll_interval: int = 5,
+    ):
         """
         Watch a task until it reaches a STOPPED status.
 
         Returns a description of the task on completion.
         """
         last_status = status = "UNKNOWN"
+
+        if self.stream_output:
+            log_driver = task_definition.get("logConfiguration", {}).get("logDriver")
+            if not task_definition.get("logConfiguration"):
+                self.logger.warning(
+                    f"ECSTask {self.name!r}: Logging configuration not found on task. "
+                    "Logs cannot be streamed."
+                )
+            elif not log_driver == "awslogs":
+                self.logger.warning(
+                    f"ECSTask {self.name!r}: Logging configuration uses unsupported "
+                    " driver {log_driver!r}. Logs cannot be streamed."
+                )
+            else:
+                log_config = task_definition["logConfiguration"]["options"]
+                logs_client = boto_session.client("logs")
 
         while status != "STOPPED":
             task = ecs_client.describe_tasks(tasks=[task_arn])["tasks"][0]
@@ -181,15 +270,19 @@ class ECSTask(Infrastructure):
                 )
 
             last_status = status
+
+            if self.stream_output and log_config:
+                response = logs_client.get_log_events(
+                    logGroupName=log_config["awslogs-group"],
+                    logStreamName=log_config["awslogs-stream-prefix"],
+                )
+                log_events = response["events"]
+                for log_event in log_events:
+                    self.logger.info(log_event)
+
             time.sleep(poll_interval)
 
         return task
-
-    def _get_ecs_client(self):
-        """
-        Get an AWS ECS client
-        """
-        return self.aws_credentials.get_boto3_session().client("ecs")
 
     def _retrieve_task_definition(self, ecs_client, task_definition_arn: str):
         """
@@ -223,7 +316,7 @@ class ECSTask(Infrastructure):
                 return container
         return None
 
-    def _prepare_task_definition(self, task_definition: dict) -> dict:
+    def _prepare_task_definition(self, task_definition: dict, region: str) -> dict:
         """
         Prepare a task definition by inferring any defaults and merging overrides.
         """
@@ -236,13 +329,24 @@ class ECSTask(Infrastructure):
         container = self._get_prefect_container(task_definition["containerDefinitions"])
         container["image"] = self.image
 
+        if self.configure_cloudwatch_logs:
+            container["logConfiguration"] = {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-create-group": "true",
+                    "awslogs-group": "prefect",
+                    "awslogs-region": region,
+                    "awslogs-stream-prefix": self.name or "prefect",
+                },
+            }
+
         task_definition.setdefault("family", "prefect")
 
         # CPU and memory are required in some cases, retrieve the value to use
         cpu = self.cpu or task_definition.get("cpu") or 1024
         memory = self.memory or task_definition.get("memory") or 2048
 
-        if self.launch_type == "FARGATE":
+        if self.launch_type == "FARGATE" or self.launch_type == "FARGATE_SPOT":
             # Task level memory and cpu are required when using fargate
             task_definition["cpu"] = str(cpu)
             task_definition["memory"] = str(memory)
@@ -270,6 +374,9 @@ class ECSTask(Infrastructure):
             container.setdefault("cpu", int(cpu))
             container.setdefault("memory", int(memory))
 
+        if self.execution_role_arn and not self.task_definition_arn:
+            task_definition["executionRoleArn"] = self.execution_role_arn
+
         return task_definition
 
     def _prepare_task_run_overrides(self) -> dict:
@@ -287,8 +394,10 @@ class ECSTask(Infrastructure):
             ],
         }
 
+        prefect_container_overrides = overrides["containerOverrides"][0]
+
         if self.command:
-            overrides["containerOverrides"][0]["command"] = self.command
+            prefect_container_overrides["command"] = self.command
 
         if self.execution_role_arn:
             overrides["executionRoleArn"] = self.execution_role_arn
@@ -307,12 +416,12 @@ class ECSTask(Infrastructure):
 
         return overrides
 
-    def _load_vpc_network_config(self, vpc_id: Optional[str]) -> dict:
+    def _load_vpc_network_config(self, vpc_id: Optional[str], boto_session) -> dict:
         """
         Load settings from a specific VPC or the default VPC and generate a task
         run request's network configuration.
         """
-        ec2_client = self.aws_credentials.get_boto3_session().client("ec2")
+        ec2_client = boto_session.client("ec2")
         vpc_message = "the default VPC" if not vpc_id else f"VPC with ID {vpc_id}"
 
         if not vpc_id:
@@ -351,14 +460,15 @@ class ECSTask(Infrastructure):
         }
 
     def _prepare_task_run(
-        self, network_config: Optional[dict], task_definition_arn: str
+        self,
+        network_config: Optional[dict],
+        task_definition_arn: str,
     ) -> dict:
         """
         Prepare a task run request payload.
         """
         task_run = {
             "overrides": self._prepare_task_run_overrides(),
-            "capacityProviderStrategy": self.capacity_provider_strategy,
             "tags": [
                 {"name": key, "value": value} for key, value in self.labels.items()
             ],
@@ -366,7 +476,12 @@ class ECSTask(Infrastructure):
         }
 
         if self.launch_type:
-            task_run["launchType"] = self.launch_type
+            if self.launch_type == "FARGATE_SPOT":
+                task_run["capacityProviderStrategy"] = [
+                    {"capacityProvider": "FARGATE_SPOT", "weight": 1}
+                ]
+            else:
+                task_run["launchType"] = self.launch_type
 
         if network_config:
             task_run["networkConfiguration"] = network_config

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -130,9 +130,11 @@ class ECSTask(Infrastructure):
 
         if self.task_definition or not self.task_definition_arn:
             task_definition = self._prepare_task_definition(self.task_definition or {})
-            preview += "----- Task definition -----\n"
+            preview += "---\n# Task definition\n"
             preview += yaml.dump(task_definition)
             preview += "\n"
+        else:
+            task_definition = None
 
         if task_definition and task_definition.get("networkMode") == "awsvpc":
             vpc = "the default VPC" if not self.vpc_id else self.vpc_id
@@ -141,7 +143,7 @@ class ECSTask(Infrastructure):
             network_config = None
 
         task_run = self._prepare_task_run(network_config, task_definition_arn)
-        preview += "----- Task run -----\n"
+        preview += "---\n# Task run request\n"
         preview += yaml.dump(task_run)
 
         return preview
@@ -231,9 +233,7 @@ class ECSTask(Infrastructure):
         task_definition.setdefault(
             "containerDefinitions", [{"name": ECS_TASK_RUN_CONTAINER_NAME}]
         )
-        container = self._get_prefect_container_definition(
-            task_definition["containerDefinitions"]
-        )
+        container = self._get_prefect_container(task_definition["containerDefinitions"])
         container["image"] = self.image
 
         task_definition.setdefault("family", "prefect")

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1,0 +1,44 @@
+import json
+
+import anyio
+from moto import mock_ec2, mock_ecs
+from moto.ec2.utils import generate_instance_identity_document
+
+from prefect_aws.ecs import ECSTask
+
+
+def create_test_cluster(session):
+    ecs_client = session.client("ecs")
+    ec2_client = session.client("ec2")
+    ec2_resource = session.resource("ec2")
+
+    ecs_client.create_cluster(clusterName="default")
+
+    images = ec2_client.describe_images()
+    image_id = images["Images"][0]["ImageId"]
+
+    test_instance = ec2_resource.create_instances(
+        ImageId=image_id, MinCount=1, MaxCount=1
+    )[0]
+
+    ecs_client.register_container_instance(
+        cluster="default",
+        instanceIdentityDocument=json.dumps(
+            generate_instance_identity_document(test_instance)
+        ),
+    )
+
+
+async def test_task_run(aws_credentials):
+
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        command=["prefect", "version"],
+        launch_type="EC2",
+    )
+    with mock_ecs():
+        with mock_ec2():
+            session = aws_credentials.get_boto3_session()
+            create_test_cluster(session)
+            print(task.preview())
+            await task.run()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

Adds an `ECSTask` block for running commands as ECS tasks. This will allow users to configure deployments to run flows on ECS.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->