### PR TITLE
Loosen `boto3` and `botocore` pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.24.53
-botocore==1.27.53
+boto3>=1.24.53
+botocore>=1.27.53
 prefect>=2.0


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Allow a range of `boto3` and `botocore` versions. This will help users not run into version conflicts when using `prefect-aws` and @dependabot will submit fewer dependency update PRs.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->