### PR TITLE
Changes `mkdocstrings` Python handler to support `pydantic` fields

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8
 mypy
 mkdocs
 mkdocs-material
-mkdocstrings[python]
+mkdocstrings-python-legacy
 isort
 pre-commit
 moto >= 3.1.16


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
The attributes on the `ECSTask` block aren't showing the docs. Switching to the legacy python handler for `mkdocstrings` picks them up correctly:
![Screen Shot 2022-09-14 at 4 49 24 PM](https://user-images.githubusercontent.com/12350579/190269202-8b779c1b-c9ec-448a-bf7e-ac5c02bba590.png)


## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
