### PR TITLE
Fix ability to edit pages via GitHub edit link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix configuration to submit doc edits via GitHub - [#110](https://github.com/PrefectHQ/prefect-aws/pull/110)
+
 ### Added
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+---
+description: prefect-aws provides pre-built Prefect tasks for working with Amazon Web Services.
+tags:
+    - overview
+    - getting started
+    - installation
+    - examples
+---
+
 # prefect-aws
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
----
-description: prefect-aws provides pre-built Prefect tasks for working with Amazon Web Services.
-tags:
-    - overview
-    - getting started
-    - installation
-    - examples
----
-
 # prefect-aws
 
 <p align="center">

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,6 +1,6 @@
 ---
 description: Tasks for interacting with AWS Batch
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.batch

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,1 +1,6 @@
+---
+description: Tasks for interacting with AWS Batch
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.batch

--- a/docs/client_waiter.md
+++ b/docs/client_waiter.md
@@ -1,1 +1,6 @@
+---
+description: Task for waiting on a long-running AWS job
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.client_waiter

--- a/docs/client_waiter.md
+++ b/docs/client_waiter.md
@@ -1,6 +1,6 @@
 ---
 description: Task for waiting on a long-running AWS job
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.client_waiter

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,6 +1,6 @@
 ---
 description: Module handling AWS credentials
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.credentials

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,1 +1,6 @@
+---
+description: Module handling AWS credentials
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.credentials

--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -1,1 +1,6 @@
+---
+description: Integrations with the Amazon Elastic Container Service.
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.ecs

--- a/docs/ecs.md
+++ b/docs/ecs.md
@@ -1,6 +1,6 @@
 ---
 description: Integrations with the Amazon Elastic Container Service.
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.ecs

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -1,6 +1,6 @@
 ---
 description: Tasks for interacting with AWS S3
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.s3

--- a/docs/s3.md
+++ b/docs/s3.md
@@ -1,1 +1,6 @@
+---
+description: Tasks for interacting with AWS S3
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.s3

--- a/docs/secrets_manager.md
+++ b/docs/secrets_manager.md
@@ -1,1 +1,6 @@
+---
+description: Tasks for interacting with AWS Secrets Manager
+notes: This documentation pages is generated from source file docstrings.
+---
+
 ::: prefect_aws.secrets_manager

--- a/docs/secrets_manager.md
+++ b/docs/secrets_manager.md
@@ -1,6 +1,6 @@
 ---
 description: Tasks for interacting with AWS Secrets Manager
-notes: This documentation pages is generated from source file docstrings.
+notes: This documentation page is generated from source file docstrings.
 ---
 
 ::: prefect_aws.secrets_manager

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,9 +46,9 @@ plugins:
 
 nav:
     - Home: index.md
+    - Batch: batch.md
+    - Client Waiter: client_waiter.md
     - Credentials: credentials.md
+    - ECS: ecs.md
     - S3: s3.md
     - Secrets Manager: secrets_manager.md
-    - Batch: batch.md
-    - ECS: ecs.md
-    - Client Waiter: client_waiter.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: prefect-aws
 site_url: https://prefecthq.github.io/prefect-aws
 repo_url: https://github.com/prefecthq/prefect-aws
-edit_uri: /edit/main/docs/
+edit_uri: edit/main/docs/
 theme:
   name: material
   favicon: img/favicon.ico


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

Fix misconfigured edit path to enable submitting edits via the "Pencil" edit link.

In addition:

- Adds yaml frontmatter to doc pages
- Frontmatter includes a note indicating that API pages are generated from docstrings in source files. This gives some indication to a user who wants to edit the API docs, but selects the edit pencil and finds a basically blank page. 

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [X] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
