### PR TITLE
Add `cloudwatch_logs_options` to customize `configure_cloudwatch_logs` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix configuration to submit doc edits via GitHub - [#110](https://github.com/PrefectHQ/prefect-aws/pull/110)
+- Add `ECSTask.cloudwatch_logs_options` for customization of CloudWatch logging — [#116](https://github.com/PrefectHQ/prefect-aws/pull/116)
 
 ### Added
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -212,13 +212,13 @@ class ECSTask(Infrastructure):
             "unless `stream_output` is set. "
         ),
     )
-    cloudwatch_logs_options: Optional[Dict[str, str]] = Field(
-        default=None,
+    cloudwatch_logs_options: Dict[str, str] = Field(
+        default_factory=dict,
         description=(
-            "When `configure_cloudwatch_logs`, this setting may be used to pass "
-            "additional options to the CloudWatch logs configuration or override "
-            "the default options. See [the AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#create_awslogs_logdriver_options) "  # noqa
-            "for available options."
+            "When `configure_cloudwatch_logs` is enabled, this setting may be used to "
+            "pass additional options to the CloudWatch logs configuration or override "
+            "the default options. See the AWS documentation for available options. "
+            "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#create_awslogs_logdriver_options"  # noqa
         ),
     )
     stream_output: bool = Field(
@@ -874,7 +874,7 @@ class ECSTask(Infrastructure):
                     "awslogs-group": "prefect",
                     "awslogs-region": region,
                     "awslogs-stream-prefix": self.name or "prefect",
-                    **(self.cloudwatch_logs_options or {}),
+                    **self.cloudwatch_logs_options,
                 },
             }
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -212,6 +212,15 @@ class ECSTask(Infrastructure):
             "unless `stream_output` is set. "
         ),
     )
+    cloudwatch_logs_options: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "When `configure_cloudwatch_logs`, this setting may be used to pass "
+            "additional options to the CloudWatch logs configuration or override "
+            "the default options. See [the AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#create_awslogs_logdriver_options) "  # noqa
+            "for available options."
+        ),
+    )
     stream_output: bool = Field(
         default=None,
         description=(
@@ -318,6 +327,23 @@ class ECSTask(Infrastructure):
             raise ValueError(
                 "An `execution_role_arn` must be provided to use "
                 "`configure_cloudwatch_logs` or `stream_logs`."
+            )
+        return values
+
+    @root_validator
+    def cloudwatch_logs_options_requires_configure_cloudwatch_logs(
+        cls, values: dict
+    ) -> dict:
+        """
+        Enforces that an execution role arn is provided (or could be provided by a
+        runtime task definition) when configuring logging.
+        """
+        if values.get("cloudwatch_logs_options") and not values.get(
+            "configure_cloudwatch_logs"
+        ):
+            raise ValueError(
+                "`configure_cloudwatch_log` must be enabled to use "
+                "`cloudwatch_logs_options`."
             )
         return values
 
@@ -848,6 +874,7 @@ class ECSTask(Infrastructure):
                     "awslogs-group": "prefect",
                     "awslogs-region": region,
                     "awslogs-stream-prefix": self.name or "prefect",
+                    **(self.cloudwatch_logs_options or {}),
                 },
             }
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

Allows additional options or overrides to be passed to the awslogs driver. 

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

Closes https://github.com/PrefectHQ/prefect-aws/issues/114

## Checklist
- [x] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
