### PR TITLE
Added support for advanced AwsClientParameters configuration (e.g. public S3 buckets) and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration to submit doc edits via GitHub - [#110](https://github.com/PrefectHQ/prefect-aws/pull/110)
 - Add `ECSTask.cloudwatch_logs_options` for customization of CloudWatch logging — [#116](https://github.com/PrefectHQ/prefect-aws/pull/116)
+- Added `config` parameter to AwsClientParameters to support advanced configuration (e.g. accessing public S3 buckets) [#104](https://github.com/PrefectHQ/prefect-aws/pull/117)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration to submit doc edits via GitHub - [#110](https://github.com/PrefectHQ/prefect-aws/pull/110)
 - Add `ECSTask.cloudwatch_logs_options` for customization of CloudWatch logging — [#116](https://github.com/PrefectHQ/prefect-aws/pull/116)
-- Added `config` parameter to AwsClientParameters to support advanced configuration (e.g. accessing public S3 buckets) [#104](https://github.com/PrefectHQ/prefect-aws/pull/117)
+- Added `config` parameter to AwsClientParameters to support advanced configuration (e.g. accessing public S3 buckets) [#117](https://github.com/PrefectHQ/prefect-aws/pull/117)
 
 ### Added
 

--- a/prefect_aws/client_parameters.py
+++ b/prefect_aws/client_parameters.py
@@ -3,13 +3,14 @@
 import dataclasses
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
+from botocore.client import Config
 
 
 @dataclass(frozen=True)
 class AwsClientParameters:
     """
     Dataclass used to manage extra parameters that you can pass when you initialize the Client. If you
-    want find more information
+    want to find more information, see
     [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html)
     for more info about the possible client configurations.
 
@@ -38,12 +39,17 @@ class AwsClientParameters:
             can specify a complete URL (including the "http/https" scheme)
             to override this behavior. If this value is provided,
             then ``use_ssl`` is ignored.
+
+        config: Advanced configuration for Botocore clients. See
+            [botocore docs](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html)
+            for more details.
     """  # noqa E501
 
     api_version: Optional[str] = None
     use_ssl: Optional[bool] = None
     verify: Optional[Union[bool, str]] = None
     endpoint_url: Optional[str] = None
+    config: Optional[Config] = None
 
     def get_params_override(self) -> Dict[str, Any]:
         """

--- a/prefect_aws/client_parameters.py
+++ b/prefect_aws/client_parameters.py
@@ -3,6 +3,7 @@
 import dataclasses
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
+
 from botocore.client import Config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import pytest
+from botocore import UNSIGNED
+from botocore.client import Config
 from prefect.testing.utilities import prefect_test_harness
 
 from prefect_aws import AwsCredentials
 from prefect_aws.client_parameters import AwsClientParameters
-from botocore import UNSIGNED
-from botocore.client import Config
 
 
 # added to eliminate warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,15 @@ from prefect.testing.utilities import prefect_test_harness
 
 from prefect_aws import AwsCredentials
 from prefect_aws.client_parameters import AwsClientParameters
+from botocore import UNSIGNED
+from botocore.client import Config
+
+
+# added to eliminate warnings
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "is_public: mark test as using public S3 bucket or not"
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -28,3 +37,8 @@ def aws_client_parameters_custom_endpoint():
 @pytest.fixture
 def aws_client_parameters_empty():
     return AwsClientParameters()
+
+
+@pytest.fixture
+def aws_client_parameters_public_bucket():
+    return AwsClientParameters(config=Config(signature_version=UNSIGNED))

--- a/tests/test_client_parameters.py
+++ b/tests/test_client_parameters.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
-from botocore.client import Config
 
 import pytest
+from botocore.client import Config
 
 from prefect_aws.client_parameters import AwsClientParameters
 
@@ -30,11 +30,22 @@ from prefect_aws.client_parameters import AwsClientParameters
             AwsClientParameters(api_version="1.0.0"),
             {"api_version": "1.0.0"},
         ),
-        pytest.param(
+    ],
+)
+def test_empty_AwsClientParameter_return_empty_dict(
+    params: AwsClientParameters, result: Dict[str, Any]
+):
+    assert result == params.get_params_override()
+
+
+@pytest.mark.parametrize(
+    "params,result",
+    [
+        (
             AwsClientParameters(
                 config=Config(
                     region_name="eu_west_1",
-                    retries={"max_attempts": 10, "mode": "standard"}
+                    retries={"max_attempts": 10, "mode": "standard"},
                 )
             ),
             {
@@ -43,11 +54,14 @@ from prefect_aws.client_parameters import AwsClientParameters
                     "retries": {"max_attempts": 10, "mode": "standard"},
                 },
             },
-            marks=pytest.mark.xfail(reason="boto3 Config not directly equivalent to a dict"),
         ),
     ],
 )
-def test_empty_AwsClientParameter_return_empty_dict(
+def test_AwsClientParameter_with_custom_config(
     params: AwsClientParameters, result: Dict[str, Any]
 ):
-    assert result == params.get_params_override()
+    assert (
+        result["config"]["region_name"]
+        == params.get_params_override()["config"].region_name
+    )
+    assert result["config"]["retries"] == params.get_params_override()["config"].retries

--- a/tests/test_client_parameters.py
+++ b/tests/test_client_parameters.py
@@ -29,6 +29,20 @@ from prefect_aws.client_parameters import AwsClientParameters
             AwsClientParameters(api_version="1.0.0"),
             {"api_version": "1.0.0"},
         ),
+        # would need to implement a custom equality function or class matcher,
+        # but this is too trivial of a test
+        # (
+        #     AwsClientParameters(config=botocore.client.Config(
+        #         region_name="eu_west_1",
+        #         retries={"max_attempts": 10, "mode": "standard"}
+        #     )),
+        #     {
+        #         "config": {
+        #             "region_name": "eu_west_1",
+        #             "retries": {"max_attempts": 10, "mode": "standard"},
+        #         }
+        #     },
+        # ),
     ],
 )
 def test_empty_AwsClientParameter_return_empty_dict(

--- a/tests/test_client_parameters.py
+++ b/tests/test_client_parameters.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+from botocore.client import Config
 
 import pytest
 
@@ -29,20 +30,21 @@ from prefect_aws.client_parameters import AwsClientParameters
             AwsClientParameters(api_version="1.0.0"),
             {"api_version": "1.0.0"},
         ),
-        # would need to implement a custom equality function or class matcher,
-        # but this is too trivial of a test
-        # (
-        #     AwsClientParameters(config=botocore.client.Config(
-        #         region_name="eu_west_1",
-        #         retries={"max_attempts": 10, "mode": "standard"}
-        #     )),
-        #     {
-        #         "config": {
-        #             "region_name": "eu_west_1",
-        #             "retries": {"max_attempts": 10, "mode": "standard"},
-        #         }
-        #     },
-        # ),
+        pytest.param(
+            AwsClientParameters(
+                config=Config(
+                    region_name="eu_west_1",
+                    retries={"max_attempts": 10, "mode": "standard"}
+                )
+            ),
+            {
+                "config": {
+                    "region_name": "eu_west_1",
+                    "retries": {"max_attempts": 10, "mode": "standard"},
+                },
+            },
+            marks=pytest.mark.xfail(reason="boto3 Config not directly equivalent to a dict"),
+        ),
     ],
 )
 def test_empty_AwsClientParameter_return_empty_dict(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -37,7 +37,7 @@ def bucket(s3_mock, request):
     bucket = s3.Bucket("bucket")
     marker = request.node.get_closest_marker("is_public", None)
     if marker and marker.args[0]:
-        bucket.create(ACL='public-read')
+        bucket.create(ACL="public-read")
     else:
         bucket.create()
     return bucket
@@ -98,19 +98,33 @@ async def test_s3_download_failed_with_wrong_endpoint_setup(
 @pytest.mark.parametrize(
     "client_parameters",
     [
-        pytest.param(lazy_fixture("aws_client_parameters_custom_endpoint"),
-                     marks=pytest.mark.is_public(False)),
-        pytest.param(lazy_fixture("aws_client_parameters_custom_endpoint"),
-                     marks=pytest.mark.is_public(True)),
-        pytest.param(lazy_fixture("aws_client_parameters_empty"),
-                     marks=pytest.mark.is_public(False)),
-        pytest.param(lazy_fixture("aws_client_parameters_empty"),
-                     marks=pytest.mark.is_public(True)),
-        pytest.param(lazy_fixture("aws_client_parameters_public_bucket"),
-                     marks=[pytest.mark.is_public(False),
-                            pytest.mark.xfail(reason="Bucket is not a public one")]),
-        pytest.param(lazy_fixture("aws_client_parameters_public_bucket"),
-                     marks=pytest.mark.is_public(True)),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_custom_endpoint"),
+            marks=pytest.mark.is_public(False),
+        ),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_custom_endpoint"),
+            marks=pytest.mark.is_public(True),
+        ),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_empty"),
+            marks=pytest.mark.is_public(False),
+        ),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_empty"),
+            marks=pytest.mark.is_public(True),
+        ),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_public_bucket"),
+            marks=[
+                pytest.mark.is_public(False),
+                pytest.mark.xfail(reason="Bucket is not a public one"),
+            ],
+        ),
+        pytest.param(
+            lazy_fixture("aws_client_parameters_public_bucket"),
+            marks=pytest.mark.is_public(True),
+        ),
     ],
     indirect=True,
 )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -13,6 +13,7 @@ from prefect_aws.s3 import s3_download, s3_list_objects, s3_upload
 aws_clients = [
     (lazy_fixture("aws_client_parameters_custom_endpoint")),
     (lazy_fixture("aws_client_parameters_empty")),
+    (lazy_fixture("aws_client_parameters_public_bucket")),
 ]
 
 
@@ -31,10 +32,14 @@ def client_parameters(request):
 
 
 @pytest.fixture
-def bucket(s3_mock):
+def bucket(s3_mock, request):
     s3 = boto3.resource("s3")
     bucket = s3.Bucket("bucket")
-    bucket.create()
+    marker = request.node.get_closest_marker("is_public", None)
+    if marker and marker.args[0]:
+        bucket.create(ACL='public-read')
+    else:
+        bucket.create()
     return bucket
 
 
@@ -90,7 +95,25 @@ async def test_s3_download_failed_with_wrong_endpoint_setup(
         await test_flow()
 
 
-@pytest.mark.parametrize("client_parameters", aws_clients, indirect=True)
+@pytest.mark.parametrize(
+    "client_parameters",
+    [
+        pytest.param(lazy_fixture("aws_client_parameters_custom_endpoint"),
+                     marks=pytest.mark.is_public(False)),
+        pytest.param(lazy_fixture("aws_client_parameters_custom_endpoint"),
+                     marks=pytest.mark.is_public(True)),
+        pytest.param(lazy_fixture("aws_client_parameters_empty"),
+                     marks=pytest.mark.is_public(False)),
+        pytest.param(lazy_fixture("aws_client_parameters_empty"),
+                     marks=pytest.mark.is_public(True)),
+        pytest.param(lazy_fixture("aws_client_parameters_public_bucket"),
+                     marks=[pytest.mark.is_public(False),
+                            pytest.mark.xfail(reason="Bucket is not a public one")]),
+        pytest.param(lazy_fixture("aws_client_parameters_public_bucket"),
+                     marks=pytest.mark.is_public(True)),
+    ],
+    indirect=True,
+)
 async def test_s3_download(object, client_parameters, aws_credentials):
     @flow
     async def test_flow():


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
Added config parameter to AwsClientParameters to support advanced configuration (e.g. accessing public S3 buckets)

## Relevant Issue(s)
Issues #104 and #102

## Checklist
- [x] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
