### PR TITLE
add sync_compatible decorator to S3Bucket methods

### DIFF
--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -9,7 +9,7 @@ import boto3
 from botocore.paginate import PageIterator
 from prefect import get_run_logger, task
 from prefect.filesystems import ReadableFileSystem, WritableFileSystem
-from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from pydantic import root_validator, validator
 
 from prefect_aws import AwsCredentials, MinIOCredentials
@@ -340,6 +340,7 @@ class S3Bucket(ReadableFileSystem, WritableFileSystem):
 
         return s3_client
 
+    @sync_compatible
     async def read_path(self, path: str) -> bytes:
 
         """
@@ -388,6 +389,7 @@ class S3Bucket(ReadableFileSystem, WritableFileSystem):
             output = stream.read()
             return output
 
+    @sync_compatible
     async def write_path(self, path: str, content: bytes) -> str:
 
         """


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
Allows `S3Bucket` methods to be called in a synchronous context.

## Relevant Issue(s)
Closes #118 

## Checklist
- [x] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
