### PR TITLE
Add support for JSON patch customizations of the `ECSTask` task run payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix configuration to submit doc edits via GitHub - [#110](https://github.com/PrefectHQ/prefect-aws/pull/110)
 - Add `ECSTask.cloudwatch_logs_options` for customization of CloudWatch logging — [#116](https://github.com/PrefectHQ/prefect-aws/pull/116)
 - Add `@sync_compatible` to `S3Bucket` methods to allow calling them in sync contexts - [#119](https://github.com/PrefectHQ/prefect-aws/pull/119).
+- Add `ECSTask.task_customizations` for customization of arbitary fields in the run task payload — [#120](https://github.com/PrefectHQ/prefect-aws/pull/120)
 
 ### Added
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -63,7 +63,7 @@ Examples:
     ECSTask(command=["echo", "hello world"], cluster="my-cluster-name")
     ```
 
-    Run a task with custom subnets
+    Run a task with custom VPC subnets
     ```python
     ECSTask(
         command=["echo", "hello world"],
@@ -77,15 +77,16 @@ Examples:
     )
     ```
 
-    Run a task with custom VPC subnets
+    Run a task without a public IP assigned
     ```python
     ECSTask(
         command=["echo", "hello world"],
+        vpc_id="vpc-01abcdf123456789a",
         task_customizations=[
             {
-                "op": "add",
-                "path": "/networkConfiguration/awsvpcConfiguration/subnets",
-                "value": ["subnet-80b6fbcd", "subnet-42a6fdgd"],
+                "op": "replace",
+                "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp",
+                "value": "DISABLED",
             },
         ]
     )

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1253,3 +1253,129 @@ async def test_deregister_task_definition_does_not_apply_to_linked_arn(aws_crede
     task = describe_task(ecs_client, task_arn)
     # The task definition can be retrieved still
     assert describe_task_definition(ecs_client, task)
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_adding_security_groups_to_network_config(aws_credentials):
+    session = aws_credentials.get_boto3_session()
+    ec2_resource = session.resource("ec2")
+    vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2_resource.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id)
+    ec2_client = session.client("ec2")
+    security_group_id = ec2_client.create_security_group(
+        GroupName="test", Description="testing"
+    )["GroupId"]
+
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        vpc_id=vpc.id,
+        task_customizations=[
+            {
+                "op": "add",
+                "path": "/networkConfiguration/awsvpcConfiguration/securityGroups",
+                "value": [security_group_id],
+            },
+        ],
+    )
+
+    # Capture the task run call because moto does not track 'networkConfiguration'
+    original_run_task = task._run_task
+    mock_run_task = MagicMock(side_effect=original_run_task)
+    task._run_task = mock_run_task
+
+    print(task.preview())
+
+    await run_then_stop_task(task)
+
+    network_configuration = mock_run_task.call_args[0][1].get("networkConfiguration")
+
+    # Subnet ids are copied from the vpc
+    assert network_configuration == {
+        "awsvpcConfiguration": {
+            "subnets": [subnet.id],
+            "securityGroups": [security_group_id],
+            "assignPublicIp": "ENABLED",
+        }
+    }
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_disable_public_ip_in_network_config(aws_credentials):
+    session = aws_credentials.get_boto3_session()
+    ec2_resource = session.resource("ec2")
+    vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2_resource.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id)
+
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        vpc_id=vpc.id,
+        task_customizations=[
+            {
+                "op": "replace",
+                "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp",
+                "value": "DISABLED",
+            },
+        ],
+    )
+
+    # Capture the task run call because moto does not track 'networkConfiguration'
+    original_run_task = task._run_task
+    mock_run_task = MagicMock(side_effect=original_run_task)
+    task._run_task = mock_run_task
+
+    print(task.preview())
+
+    await run_then_stop_task(task)
+
+    network_configuration = mock_run_task.call_args[0][1].get("networkConfiguration")
+
+    # Subnet ids are copied from the vpc
+    assert network_configuration == {
+        "awsvpcConfiguration": {
+            "subnets": [subnet.id],
+            "assignPublicIp": "DISABLED",
+        }
+    }
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_custom_subnets_in_the_network_configuration(aws_credentials):
+    session = aws_credentials.get_boto3_session()
+    ec2_resource = session.resource("ec2")
+    vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2_resource.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id)
+
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        task_customizations=[
+            {
+                "op": "add",
+                "path": "/networkConfiguration/awsvpcConfiguration/subnets",
+                "value": [subnet.id],
+            },
+            {
+                "op": "add",
+                "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp",
+                "value": "DISABLED",
+            },
+        ],
+    )
+
+    # Capture the task run call because moto does not track 'networkConfiguration'
+    original_run_task = task._run_task
+    mock_run_task = MagicMock(side_effect=original_run_task)
+    task._run_task = mock_run_task
+
+    print(task.preview())
+
+    await run_then_stop_task(task)
+
+    network_configuration = mock_run_task.call_args[0][1].get("networkConfiguration")
+
+    # Subnet ids are copied from the vpc
+    assert network_configuration == {
+        "awsvpcConfiguration": {
+            "subnets": [subnet.id],
+            "assignPublicIp": "DISABLED",
+        }
+    }


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

This exposes customizations of the payload for ECS task runs, allowing users to set fields not available at the top level or override any of the options that Prefect sets.

We follow the JSON Patch customizations pattern used in the core library for Kubernetes. Tests and examples have been added for the current user requests. Future requests can be followed with new documentation examples, as patches can be challenging to write at times.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

Closes https://github.com/PrefectHQ/prefect-aws/issues/115
Closes https://github.com/PrefectHQ/prefect-aws/issues/113
Closes https://github.com/PrefectHQ/prefect-aws/issues/112
 
## Checklist
- [x] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
