### PR TITLE
Tweak mkdocs and docstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,8 @@ plugins:
           rendering:
             show_root_heading: True
             show_object_full_path: False
-            show_category_heading: False
-            show_bases: False
+            show_category_heading: True
+            show_bases: True
             show_signature: False
             heading_level: 1
       watch:

--- a/prefect_aws/batch.py
+++ b/prefect_aws/batch.py
@@ -15,7 +15,7 @@ async def batch_submit(
     job_definition: str,
     aws_credentials: AwsCredentials,
     **batch_kwargs: Optional[Dict[str, Any]],
-):
+) -> str:
     """
     Submit a job to the AWS Batch job service.
 

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import boto3
 from prefect.blocks.core import Block
-from pydantic import SecretStr, Field
+from pydantic import Field, SecretStr
 
 
 class AwsCredentials(Block):

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import boto3
 from prefect.blocks.core import Block
-from pydantic import SecretStr
+from pydantic import SecretStr, Field
 
 
 class AwsCredentials(Block):
@@ -13,14 +13,6 @@ class AwsCredentials(Block):
     handled via the `boto3` module. Refer to the
     [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
     for more info about the possible credential configurations.
-
-    Args:
-        aws_access_key_id: A specific AWS access key ID.
-        aws_secret_access_key: A specific AWS secret access key.
-        aws_session_token: The session key for your AWS account.
-            This is only needed when you are using temporary credentials.
-        profile_name: The profile to use when creating your session.
-        region_name: The AWS Region where you want to create new connections.
 
     Example:
         Load stored AWS credentials:
@@ -34,11 +26,26 @@ class AwsCredentials(Block):
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/1jbV4lceHOjGgunX15lUwT/db88e184d727f721575aeb054a37e277/aws.png?h=250"  # noqa
     _block_type_name = "AWS Credentials"
 
-    aws_access_key_id: Optional[str] = None
-    aws_secret_access_key: Optional[SecretStr] = None
-    aws_session_token: Optional[str] = None
-    profile_name: Optional[str] = None
-    region_name: Optional[str] = None
+    aws_access_key_id: Optional[str] = Field(
+        default=None, description="A specific AWS access key ID."
+    )
+    aws_secret_access_key: Optional[SecretStr] = Field(
+        default=None, description="A specific AWS secret access key."
+    )
+    aws_session_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "The session key for your AWS account. "
+            "This is only needed when you are using temporary credentials."
+        ),
+    )
+    profile_name: Optional[str] = Field(
+        default=None, description="The profile to use when creating your session."
+    )
+    region_name: Optional[str] = Field(
+        default=None,
+        description="The AWS Region where you want to create new connections.",
+    )
 
     def get_boto3_session(self) -> boto3.Session:
         """


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-aws! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

Reference:
https://mkdocstrings.github.io/python-legacy/usage/#global-only-options

With show_bases, it shows the base class:
![image](https://user-images.githubusercontent.com/15331990/193702824-07e4ab63-9923-47e1-9a50-4ecd1af1e3e9.png)

With show_category_headings, it groups by methods, attributes, functions, etc, which I like since it's much easier to discern what's what:
![image](https://user-images.githubusercontent.com/15331990/193702894-0132185a-e9e1-4048-a61a-0da462838499.png)

However, it makes Attribute names really small (could this be fixed with some CSS @tpdorsey?)
![image](https://user-images.githubusercontent.com/15331990/193702927-ed308ed5-cfca-427e-bf2a-8a8fa5a52ecd.png)

Also, I tried removing the docstring's Attribute/Args section so there's one source of truth, but I like the table more than the way `Field(description=...)` is rendered; also Field doesn't show it's optional.
![image](https://user-images.githubusercontent.com/15331990/193702980-e2aad9c2-b355-41f6-ae27-450f2302169c.png)

Here's the before (Type shows up when Args -> Attributes):

![image](https://user-images.githubusercontent.com/15331990/193703104-2afcfd50-b16a-4c7b-adde-a9f0a60b51c6.png)

![image](https://user-images.githubusercontent.com/15331990/193703139-2e0b8ce5-ae3f-4bf8-87b8-8bc9219bda00.png)

If we include both `Field()` and `Attributes` section, the attributes are first shown in the table, then listed again below:
![image](https://user-images.githubusercontent.com/15331990/193703325-cae709d7-b73e-4ae0-a5ad-1b3d8faf5626.png)


## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in the **Unreleased** section of the [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
