### PR TITLE
Fix ignore_file option in S3Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix ignore_file option in `S3Bucket` skipping files which should be included — [#139](https://github.com/PrefectHQ/prefect-aws/pull/139)
 
 ### Security
 

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -458,7 +458,10 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
 
         uploaded_file_count = 0
         for local_file_path in Path(local_path).expanduser().rglob("*"):
-            if included_files is not None and local_file_path not in included_files:
+            if (
+                included_files is not None
+                and str(local_file_path.relative_to(local_path)) not in included_files
+            ):
                 continue
             elif not local_file_path.is_dir():
                 remote_file_path = Path(to_path) / local_file_path.relative_to(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-aws 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

<!-- Link to issue -->
Closes #140


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

When using `S3Bucket.put_directory(ignore_file=".prefectignore")` the `filter_files` function is called which returns the `included_files` as strings. But the actual files are of type `path.PosixPath` and includes the whole absolute path.
As an example:

```markdown
# .prefectignore
**/folder2/*
```

```python
# called with S3Bucket.put_directory(local_path=str(tmp_path / "folder1"), ignore_file=".prefectignore"))
included_files = {'file3.txt', 'folder2', 'file4.txt'}
# not sure why the directory folder2 is included here, but the files inside folder 2 are excluded. The upload function skips directories, so thats not a big problem.
# looping over the files using local_file_path
pathlib.PosixPath("/private/var/folders/h0/jxdxc2_93m74hnycmnckqb3w0000gn/T/pytest-of-niconeumann/pytest-21/test_put_directory_with_ignore1/folder1/file3.txt")
pathlib.PosixPath("/private/var/folders/h0/jxdxc2_93m74hnycmnckqb3w0000gn/T/pytest-of-niconeumann/pytest-21/test_put_directory_with_ignore1/folder1/file4.txt")
pathlib.PosixPath("/private/var/folders/h0/jxdxc2_93m74hnycmnckqb3w0000gn/T/pytest-of-niconeumann/pytest-21/test_put_directory_with_ignore1/folder1/folder2")
pathlib.PosixPath("/private/var/folders/h0/jxdxc2_93m74hnycmnckqb3w0000gn/T/pytest-of-niconeumann/pytest-21/test_put_directory_with_ignore1/folder1/folder2/file5.txt")
```

It tries to find those absolute posix paths in the included files, which does not work and thus skips files which should be uploaded:
```python
if included_files is not None and local_path not in included_files:
    continue
```

Instead I use the relative path and parse it to a string:
```python
if (
    included_files is not None
    and str(local_file_path.relative_to(local_path)) not in included_files
):
    continue
```

```python
# called with S3Bucket.put_directory(local_path=str(tmp_path / "folder1"), ignore_file=".prefectignore"))
included_files = {'file3.txt', 'folder2', 'file4.txt'}
# looping over the files using str(local_file_path.relative_to(local_path)
"file3.txt"
"file4.txt"
"folder2"
"folder2/file5.txt"
```





### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
