### PR TITLE
Fixes double basepath error with `S3Bucket.put_directory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix ignore_file option in `S3Bucket` skipping files which should be included — [#139](https://github.com/PrefectHQ/prefect-aws/pull/139)
+- Fixed bug where `basepath` is used twice in the path when using `S3Bucket.put_directory` - [#143](https://github.com/PrefectHQ/prefect-aws/pull/139)
 
 ### Security
 
 ## 0.1.6
 
-Released on Obtober 19th, 2022.
+Released on October 19th, 2022.
 
 ### Added
 

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -425,7 +425,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
     async def put_directory(
         self,
         local_path: Optional[str] = None,
-        to_path: str = "",
+        to_path: Optional[str] = None,
         ignore_file: Optional[str] = None,
     ) -> int:
         """
@@ -443,6 +443,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
                 filepaths to ignore.
 
         """
+        to_path = "" if to_path is None else to_path
 
         if local_path is None:
             local_path = "."

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -425,7 +425,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
     async def put_directory(
         self,
         local_path: Optional[str] = None,
-        to_path: Optional[str] = None,
+        to_path: str = "",
         ignore_file: Optional[str] = None,
     ) -> int:
         """
@@ -443,8 +443,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
                 filepaths to ignore.
 
         """
-        if to_path is None:
-            to_path = str(self.basepath) if self.basepath is not None else ""
 
         if local_path is None:
             local_path = "."
@@ -505,6 +503,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
             key_contents = s3_bucket_block.read_path(path="subfolder/file1")
             ```
         """
+        path = self._resolve_path(path)
 
         return await run_sync_in_worker_thread(self._read_sync, path)
 

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -122,7 +122,7 @@ async def test_aws_basepath(s3_bucket, aws_creds_block):
     )
 
     key = await s3_bucket_block.write_path("test.txt", content=b"hello")
-    assert await s3_bucket_block.read_path(key) == b"hello"
+    assert await s3_bucket_block.read_path("test.txt") == b"hello"
     assert key == "subfolder/test.txt"
 
 
@@ -212,21 +212,12 @@ async def test_put_directory_respects_basepath(
 
     await s3_bucket_block.get_directory(local_path=str(tmp_path / "downloaded_files"))
 
-    assert (tmp_path / "downloaded_files" / "subfolder" / "file1.txt").exists()
-    assert (tmp_path / "downloaded_files" / "subfolder" / "file2.txt").exists()
+    assert (tmp_path / "downloaded_files" / "file1.txt").exists()
+    assert (tmp_path / "downloaded_files" / "file2.txt").exists()
+    assert (tmp_path / "downloaded_files" / "folder1" / "file3.txt").exists()
+    assert (tmp_path / "downloaded_files" / "folder1" / "file4.txt").exists()
     assert (
-        tmp_path / "downloaded_files" / "subfolder" / "folder1" / "file3.txt"
-    ).exists()
-    assert (
-        tmp_path / "downloaded_files" / "subfolder" / "folder1" / "file4.txt"
-    ).exists()
-    assert (
-        tmp_path
-        / "downloaded_files"
-        / "subfolder"
-        / "folder1"
-        / "folder2"
-        / "file5.txt"
+        tmp_path / "downloaded_files" / "folder1" / "folder2" / "file5.txt"
     ).exists()
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-aws 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
Fixes a bug where the `basepath` configured on the `S3Bucket` is used twice when calling `put_directory`. The root cause was determined by @neumann-nico in #141. A couple of tests were not reflecting the desired behavior for `S3Bucket.put_directory` and `S3Bucket.read_path`, so those tests have been updated to reflect the expected behavior and the corresponding methods have been updated accordingly.

<!-- Link to issue -->
Closes #141 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
