### PR TITLE
Generate `ECSTask` family names from deployment and flow metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `family` field to `ECSTask` to configure task definition family names — [#152](https://github.com/PrefectHQ/prefect-aws/pull/152)
+
 ### Changed
+
+- Changes the default `ECSTask` family to include the flow and deployment names if available — [#152](https://github.com/PrefectHQ/prefect-aws/pull/152)
 
 ### Deprecated
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -433,16 +433,24 @@ class ECSTask(Infrastructure):
     def cast_customizations_to_a_json_patch(
         cls, value: Union[List[Dict], JsonPatch]
     ) -> JsonPatch:
+        """
+        Casts lists to JsonPatch instances.
+        """
         if isinstance(value, list):
             return JsonPatch(value)
         return value
 
     class Config:
+        """Configuration of pydantic."""
+
         # Support serialization of the 'JsonPatch' type
         arbitrary_types_allowed = True
         json_encoders = {JsonPatch: lambda p: p.patch}
 
     def dict(self, *args, **kwargs) -> Dict:
+        """
+        Convert to a dictionary.
+        """
         # Support serialization of the 'JsonPatch' type
         d = super().dict(*args, **kwargs)
         d["task_customizations"] = self.task_customizations.patch

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from functools import partial
 from typing import Callable, Dict, List
 from unittest.mock import MagicMock
@@ -9,6 +10,7 @@ import yaml
 from moto import mock_ec2, mock_ecs, mock_logs
 from moto.ec2.utils import generate_instance_identity_document
 from prefect.logging.configuration import setup_logging
+from prefect.orion.schemas.core import Deployment, Flow, FlowRun
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from pydantic import ValidationError
 
@@ -1137,10 +1139,7 @@ async def test_task_definition_arn(aws_credentials):
 @pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize(
     "overrides",
-    [
-        {"image": "new-image"},
-        {"configure_cloudwatch_logs": True},
-    ],
+    [{"image": "new-image"}, {"configure_cloudwatch_logs": True}, {"family": "foobar"}],
 )
 async def test_task_definition_arn_with_overrides_that_require_copy(
     aws_credentials, overrides
@@ -1383,29 +1382,89 @@ async def test_custom_subnets_in_the_network_configuration(aws_credentials):
 
 @pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize(
-    "labels,expected_family",
+    "fields,prepare_inputs,expected_family",
     [
-        ({}, "prefect"),
-        ({"prefect.io/deployment-name": "foo"}, "prefect_foo"),
-        ({"prefect.io/flow-name": "foo"}, "prefect_foo"),
-        # Length limited to 255
-        ({"prefect.io/flow-name": "x" * 300}, "prefect_" + "x" * (255 - 8)),
-        # Spaces are not allowed
-        ({"prefect.io/flow-name": "foo bar"}, "prefect_foo-bar"),
-        # Special characters are not allowed
-        ({"prefect.io/flow-name": "foo*bar&!"}, "prefect_foo-bar"),
-        #
+        # Default
+        ({}, {}, "prefect"),
+        # Only flow
+        ({}, {"flow": Flow(name="foo")}, "prefect__foo"),
+        # Only deployment
         (
-            {"prefect.io/flow-name": "foo", "prefect.io/deployment-name": "bar"},
-            "prefect_foo_bar",
+            {},
+            {"deployment": Deployment.construct(name="foo")},
+            "prefect__unknown-flow__foo",
+        ),
+        # Flow and deployment
+        (
+            {},
+            {
+                "flow": Flow(name="foo"),
+                "deployment": Deployment.construct(name="bar"),
+            },
+            "prefect__foo__bar",
+        ),
+        # Family provided as a field
+        (
+            {"family": "test"},
+            {
+                "flow": Flow(name="foo"),
+                "deployment": Deployment.construct(name="bar"),
+            },
+            "test",
+        ),
+        # Family provided in a task definition
+        (
+            {"task_definition": {"family": "test"}},
+            {
+                "flow": Flow(name="foo"),
+                "deployment": Deployment.construct(name="bar"),
+            },
+            "test",
         ),
     ],
 )
-async def test_default_family_name(aws_credentials, labels, expected_family):
+async def test_family_from_flow_run_metadata(
+    aws_credentials, fields, prepare_inputs, expected_family
+):
+    prepare_inputs.setdefault("flow_run", FlowRun.construct())
+
     task = ECSTask(
         aws_credentials=aws_credentials,
         auto_deregister_task_definition=False,
-        labels=labels,
+        **fields,
+    ).prepare_for_flow_run(**prepare_inputs)
+    print(task.preview())
+
+    session = aws_credentials.get_boto3_session()
+    ecs_client = session.client("ecs")
+
+    task_arn = await run_then_stop_task(task)
+
+    task = describe_task(ecs_client, task_arn)
+    task_definition = describe_task_definition(ecs_client, task)
+    assert task_definition["family"] == expected_family
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+@pytest.mark.parametrize(
+    "given_family,expected_family",
+    [
+        # Default
+        (None, "prefect"),
+        ("", "prefect"),
+        # Length limited to 255
+        ("x" * 300, "x" * 255),
+        # Spaces are not allowed
+        ("foo bar", "foo-bar"),
+        # Special characters are not allowed
+        ("foo*bar&!", "foo-bar"),
+    ],
+)
+async def test_user_provided_family(aws_credentials, given_family, expected_family):
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        auto_deregister_task_definition=False,
+        family=given_family,
     )
     print(task.preview())
 
@@ -1417,3 +1476,35 @@ async def test_default_family_name(aws_credentials, labels, expected_family):
     task = describe_task(ecs_client, task_arn)
     task_definition = describe_task_definition(ecs_client, task)
     assert task_definition["family"] == expected_family
+
+
+@pytest.mark.parametrize("prepare_for_flow_run", [True, False])
+async def test_family_from_task_definition_arn(aws_credentials, prepare_for_flow_run):
+    session = aws_credentials.get_boto3_session()
+    ecs_client = session.client("ecs")
+
+    task_definition_arn = ecs_client.register_task_definition(
+        **{**BASE_TASK_DEFINITION, "family": "test-family"}
+    )["taskDefinition"]["taskDefinitionArn"]
+
+    task = ECSTask(
+        aws_credentials=aws_credentials,
+        auto_deregister_task_definition=False,
+        task_definition_arn=task_definition_arn,
+        launch_type="EC2",
+        image=None,
+    )
+    if prepare_for_flow_run:
+        task = task.prepare_for_flow_run(
+            flow_run=FlowRun.construct(),
+            flow=Flow(name="foo"),
+            deployment=Deployment.construct(name="bar"),
+        )
+
+    print(task.preview())
+
+    task_arn = await run_then_stop_task(task)
+
+    task = describe_task(ecs_client, task_arn)
+    task_definition = describe_task_definition(ecs_client, task)
+    assert task_definition["family"] == "test-family"

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1478,6 +1478,7 @@ async def test_user_provided_family(aws_credentials, given_family, expected_fami
     assert task_definition["family"] == expected_family
 
 
+@pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize("prepare_for_flow_run", [True, False])
 async def test_family_from_task_definition_arn(aws_credentials, prepare_for_flow_run):
     session = aws_credentials.get_boto3_session()

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from functools import partial
 from typing import Callable, Dict, List
 from unittest.mock import MagicMock


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-aws 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

<!-- Link to issue -->

Adds a `family` field to the top-level settings, defaults to `prefect` as before but can be overridden.

Generates the task definition family as `"prefect__{flow-name}__{deployment-name}"` if the metadata is passed to  `prepare_for_flow_run` and it is not set already.

See the test cases for exhaustive examples.

Requires https://github.com/PrefectHQ/prefect/pull/7479
Closes #148 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

```python
from prefect_aws.ecs import ECSTask
from prefect.orion.schemas.core import Deployment, FlowRun, Flow

print(
    ECSTask()
    .prepare_for_flow_run(
        FlowRun.construct(),
        flow=Flow.construct(name="foo"),
        deployment=Deployment.construct(name="bar"),
    )
    .preview()
)
```
```yaml
---
# Task definition
containerDefinitions:
- image: prefecthq/prefect:dev-python3.8
  name: prefect
cpu: '1024'
family: prefect__foo__bar
memory: '2048'
networkMode: awsvpc
requiresCompatibilities:
- FARGATE
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
