### PR TITLE
Fix handling when `describe_tasks` does not return any tasks during `ECSTask` watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
+- Fixed failure while watching ECS task execution when the task is missing — [#153](https://github.com/PrefectHQ/prefect-aws/pull/153)
+
+
 ### Security
 
 ## 0.1.7


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-aws 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

<!-- Link to issue -->
Closes https://github.com/PrefectHQ/prefect-aws/issues/151

This is best viewed [without whitespace changes](https://github.com/PrefectHQ/prefect-aws/pull/153/files?diff=unified&w=1)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
