### PR TITLE
New default for image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ECSTask` now logs the difference between the requested and the pre-registered task definition when using a `task_definition_arn` - [#166](https://github.com/PrefectHQ/prefect-aws/pull/166)
+- The image from `task_definition_arn` will be respected if `image` is not explicitly set - [#168](https://github.com/PrefectHQ/prefect-aws/pull/168)
 
 ### Deprecated
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -434,18 +434,20 @@ class ECSTask(Infrastructure):
         """
         has_no_image = not values.get("image")
         has_no_task_definition_arn = not values.get("task_definition_arn")
-        # image will default to the prefect image at runtime if there is a prefect container
-        # to reflect past behavior of image = Field(default_factory=get_prefect_image_name)
-        has_no_prefect_container = not get_prefect_container(
-            (values.get("task_definition") or {}).get(
-                "containerDefinitions", []
+        # image will default to the prefect image at runtime if there
+        # is a prefect container to reflect past behavior of
+        # image = Field(default_factory=get_prefect_image_name)
+        has_no_prefect_container = (
+            not get_prefect_container(
+                (values.get("task_definition") or {}).get("containerDefinitions", [])
             )
-        ) or {}
+            or {}
+        )
         if has_no_image and has_no_task_definition_arn and has_no_prefect_container:
             raise ValueError(
                 "A value for the `image` field must be provided unless already "
                 "present in the Prefect container definition from the task definition."
-            ) 
+            )
         return values
 
     @validator("task_customizations", pre=True)

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -1092,7 +1092,7 @@ class ECSTask(Infrastructure):
             # the image is explicitly set
             container["image"] = self.image
         elif container.get("image") is None:
-            # clause to lessen the breaking changes, since previously,
+            # clause to prevent breaking changes, since previously,
             # `image = Field(default_factory=get_prefect_image_name)``
             container["image"] = get_prefect_image_name()
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -398,7 +398,6 @@ async def test_container_command_from_task_definition(aws_credentials):
             "containerDefinitions": [{"name": "prefect", "command": ["echo", "hello"]}]
         },
         command=[],
-        image="prefecthq/prefect:2.1.0-python3.8",
     )
     print(task.preview())
 
@@ -756,7 +755,6 @@ async def test_environment_variables_in_task_definition(aws_credentials):
             ],
         },
         env={"FOO": "BAR", "OVERRIDE": "NEW"},
-        image="prefecthq/prefect:2.1.0-python3.8",
     )
     print(task.preview())
 
@@ -809,7 +807,6 @@ async def test_unset_environment_variables_in_task_definition(aws_credentials):
             ]
         },
         env={"FOO": None},
-        image="prefecthq/prefect:2.1.0-python3.8",
     )
     print(task.preview())
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -10,12 +10,12 @@ import pytest
 import yaml
 from moto import mock_ec2, mock_ecs, mock_logs
 from moto.ec2.utils import generate_instance_identity_document
+from prefect.docker import get_prefect_image_name
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.logging.configuration import setup_logging
 from prefect.orion.schemas.core import Deployment, Flow, FlowRun
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from pydantic import ValidationError
-from prefect.docker import get_prefect_image_name
 
 from prefect_aws.ecs import (
     ECS_DEFAULT_CPU,
@@ -979,7 +979,8 @@ async def test_network_config_from_default_vpc(aws_credentials):
         Filters=[{"Name": "vpc-id", "Values": [default_vpc_id]}]
     )["Subnets"]
 
-    task = ECSTask(aws_credentials=aws_credentials,
+    task = ECSTask(
+        aws_credentials=aws_credentials,
         image="prefecthq/prefect:2.1.0-python3.8",
     )
 
@@ -1042,7 +1043,8 @@ async def test_network_config_missing_default_vpc(aws_credentials):
     )["Vpcs"][0]["VpcId"]
     ec2_client.delete_vpc(VpcId=default_vpc_id)
 
-    task = ECSTask(aws_credentials=aws_credentials,
+    task = ECSTask(
+        aws_credentials=aws_credentials,
         image="prefecthq/prefect:2.1.0-python3.8",
     )
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect-aws/issues/138

Sets `image = Field(default=None)`, replacing `image = Field(default_factory=get_prefect_image_name, ...)`

That means:
1. If `image` is already set in task_definition/task_definition_arn and `image=None`, use image from the task definition
2. if `image` is explicitly set though, will override the task definitions image
3. if `image` is not set and there's a container named prefect, will `get_prefect_image_name`
4. If `image` is not set and there's no container named prefect, will raise an error:
```
            raise ValueError(
                "A value for the `image` field must be provided unless already "
                "present in the Prefect container definition from the task definition."
            ) 
```

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

See tests.

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
