### PR TITLE
Fix deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deployments of `S3Bucket` - [#168](https://github.com/PrefectHQ/prefect-aws/pull/168)
+
 ### Security
 
 ## 0.2.0

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -12,7 +12,7 @@ from prefect import get_run_logger, task
 from prefect.filesystems import WritableDeploymentStorage, WritableFileSystem
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.filesystem import filter_files
-from pydantic import Field, root_validator, validator
+from pydantic import Field, root_validator
 
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
@@ -269,8 +269,8 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
         description="A block containing your credentials (choose this or "
         "AWS Credentials).",
     )
-    basepath: Optional[Path] = Field(
-        default=None,
+    basepath: Optional[str] = Field(
+        default="",
         description="Location to write to and read from in the S3 bucket. Defaults to "
         "the root of the bucket.",
     )
@@ -279,19 +279,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage):
         description="URL endpoint to use for S3 compatible storage. Defaults to "
         "standard AWS S3 endpoint.",
     )
-
-    @validator("basepath", pre=True)
-    def cast_pathlib(cls, value):
-
-        """
-        If basepath provided, it means we aren't writing to the root directory
-        of the bucket. We need to ensure that it is a valid path. This is called
-        when the S3Bucket block is instantiated.
-        """
-
-        if isinstance(value, Path):
-            return str(value)
-        return value
 
     @root_validator(pre=True)
     def check_credentials(cls, values):

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -4,6 +4,7 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_s3
+from prefect.deployments import Deployment
 
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.s3 import S3Bucket
@@ -312,3 +313,14 @@ def test_write_path_in_sync_context(s3_bucket):
     key = s3_bucket.write_path("test.txt", content=b"hello")
     content = s3_bucket.read_path(key)
     assert content == b"hello"
+
+
+def test_deployment_default_basepath(s3_bucket):
+    deployment = Deployment(name="testing", storage=s3_bucket)
+    assert deployment.location == "/"
+
+
+def test_deployment_set_basepath(s3_bucket):
+    s3_bucket.basepath = "home"
+    deployment = Deployment(name="testing", storage=s3_bucket)
+    assert deployment.location == "home/"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect/issues/7583 and https://github.com/PrefectHQ/prefect-aws/issues/161

Apparently, `cast_pathlib` does not get called when you do `self.storage.basepath` so this makes type str and defaults to "" instead of None. 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
