### PR TITLE
Respect image from `task_definition_arn` and use default prefect image if no image is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The image from `task_definition_arn` will be respected if `image` is not explicitly set - [#170](https://github.com/PrefectHQ/prefect-aws/pull/170)
+
 ### Security
 
 ## 0.2.0

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -435,7 +435,7 @@ class ECSTask(Infrastructure):
         has_image = values.get("image")
         has_task_definition_arn = values.get("task_definition_arn")
 
-        if has_image or not has_task_definition_arn:
+        if has_image or has_task_definition_arn:
             return values
 
         prefect_container = (

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -434,12 +434,13 @@ class ECSTask(Infrastructure):
         """
         has_image = values.get("image")
         has_task_definition_arn = values.get("task_definition_arn")
-        image_in_task_definition = (
+        prefect_container = (
             get_prefect_container(
                 (values.get("task_definition") or {}).get("containerDefinitions", [])
             )
             or {}
-        ).get("image")
+        )
+        image_in_task_definition = prefect_container.get("image")
 
         # The image can only be null when the task_definition_arn is set
         # If a task_definition is given with a prefect container image, use that value
@@ -448,12 +449,10 @@ class ECSTask(Infrastructure):
         ):  # noqa
             values["image"] = image_in_task_definition
         # Otherwise, it should default to the Prefect base image
-        elif not has_image and not has_task_definition_arn:
+        elif not has_image and not has_task_definition_arn and prefect_container:
             values["image"] = get_prefect_image_name()
         elif (
-            not has_image
-            and not has_task_definition_arn
-            and not image_in_task_definition
+            not has_image and not has_task_definition_arn and not prefect_container
         ):  # noqa
             raise ValueError(
                 "A value for the `image` field must be provided unless already "

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -442,18 +442,17 @@ class ECSTask(Infrastructure):
         )
         image_in_task_definition = prefect_container.get("image")
 
+        if has_image:
+            return values
+
         # The image can only be null when the task_definition_arn is set
         # If a task_definition is given with a prefect container image, use that value
-        if (
-            not has_image and not has_task_definition_arn and image_in_task_definition
-        ):  # noqa
+        if not has_task_definition_arn and image_in_task_definition:
             values["image"] = image_in_task_definition
         # Otherwise, it should default to the Prefect base image
-        elif not has_image and not has_task_definition_arn and prefect_container:
+        elif not has_task_definition_arn and prefect_container:
             values["image"] = get_prefect_image_name()
-        elif (
-            not has_image and not has_task_definition_arn and not prefect_container
-        ):  # noqa
+        elif not has_task_definition_arn and not prefect_container:  # noqa
             raise ValueError(
                 "A value for the `image` field must be provided unless already "
                 "present for the Prefect container definition a given task definition."

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -432,8 +432,8 @@ class ECSTask(Infrastructure):
         """
         Enforces that an image is available if image is `None`.
         """
-        has_image = values.get("image")
-        has_task_definition_arn = values.get("task_definition_arn")
+        has_image = bool(values.get("image"))
+        has_task_definition_arn = bool(values.get("task_definition_arn"))
 
         # The image can only be null when the task_definition_arn is set
         if has_image or has_task_definition_arn:

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -435,6 +435,7 @@ class ECSTask(Infrastructure):
         has_image = values.get("image")
         has_task_definition_arn = values.get("task_definition_arn")
 
+        # The image can only be null when the task_definition_arn is set
         if has_image or has_task_definition_arn:
             return values
 
@@ -446,18 +447,12 @@ class ECSTask(Infrastructure):
         )
         image_in_task_definition = prefect_container.get("image")
 
-        # The image can only be null when the task_definition_arn is set
         # If a task_definition is given with a prefect container image, use that value
         if image_in_task_definition:
             values["image"] = image_in_task_definition
         # Otherwise, it should default to the Prefect base image
-        elif prefect_container:
+        else:
             values["image"] = get_prefect_image_name()
-        elif not prefect_container:  # noqa
-            raise ValueError(
-                "A value for the `image` field must be provided unless already "
-                "present for the Prefect container definition a given task definition."
-            )
         return values
 
     @validator("task_customizations", pre=True)

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -434,6 +434,10 @@ class ECSTask(Infrastructure):
         """
         has_image = values.get("image")
         has_task_definition_arn = values.get("task_definition_arn")
+
+        if has_image or not has_task_definition_arn:
+            return values
+
         prefect_container = (
             get_prefect_container(
                 (values.get("task_definition") or {}).get("containerDefinitions", [])
@@ -442,17 +446,14 @@ class ECSTask(Infrastructure):
         )
         image_in_task_definition = prefect_container.get("image")
 
-        if has_image:
-            return values
-
         # The image can only be null when the task_definition_arn is set
         # If a task_definition is given with a prefect container image, use that value
-        if not has_task_definition_arn and image_in_task_definition:
+        if image_in_task_definition:
             values["image"] = image_in_task_definition
         # Otherwise, it should default to the Prefect base image
-        elif not has_task_definition_arn and prefect_container:
+        elif prefect_container:
             values["image"] = get_prefect_image_name()
-        elif not has_task_definition_arn and not prefect_container:  # noqa
+        elif not prefect_container:  # noqa
             raise ValueError(
                 "A value for the `image` field must be provided unless already "
                 "present for the Prefect container definition a given task definition."

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -629,56 +629,6 @@ async def test_image_provided_not_prefect_container(aws_credentials):
 
 
 @pytest.mark.usefixtures("ecs_mocks")
-async def test_error_if_null_image_without_prefect_container(aws_credentials):
-    with pytest.raises(ValidationError, match="A value for the `image` field must be"):
-        ECSTask(
-            aws_credentials=aws_credentials,
-            auto_deregister_task_definition=False,
-            task_definition={
-                "containerDefinitions": [
-                    {
-                        "name": "not-prefect",
-                        "image": "use-this-image",
-                    }
-                ]
-            },
-            command=["prefect", "version"],
-            image=None,
-        )
-
-
-@pytest.mark.parametrize(
-    "task_definition",
-    [
-        # Empty task definition
-        {},
-        # Task definition with other container
-        {
-            "containerDefinitions": [
-                {
-                    "name": "foo",
-                }
-            ]
-        },
-    ],
-)
-@pytest.mark.usefixtures("ecs_mocks")
-async def test_error_if_null_image_without_image_in_task_definition(
-    aws_credentials, task_definition
-):
-    with pytest.raises(
-        ValidationError, match="A value for the `image` field must be provided"
-    ):
-        ECSTask(
-            aws_credentials=aws_credentials,
-            auto_deregister_task_definition=False,
-            task_definition=task_definition,
-            command=["prefect", "version"],
-            image=None,
-        )
-
-
-@pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize("launch_type", ["EC2", "FARGATE", "FARGATE_SPOT"])
 async def test_default_cpu_and_memory_in_task_definition(
     aws_credentials, launch_type: str

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -573,7 +573,7 @@ async def test_image_overrides_task_definition(aws_credentials):
 @pytest.mark.parametrize(
     "task_definition",
     [
-        # Empty task defininition
+        # Empty task definition
         {},
         # Task definition with prefect container but no image
         {


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Replaces https://github.com/PrefectHQ/prefect-aws/pull/168 with updates from review because I didn't want to manually remove all the image added in the test.

Sets `image = Field(default=None)` instead of `image = Field(default_factory=get_prefect_image_name)`

Checks if the input values contain an image or a task definition ARN. If either of those are present, it returns those. If neither are present, it checks the task definition for a Prefect container image and uses that if it is present. If no Prefect container image is found, it uses the default Prefect base image.

Closes https://github.com/PrefectHQ/prefect-aws/issues/138

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
