### PR TITLE
Fixes bug when `credentials` attribute is used with `write_path` and `read_path`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed errors raised when using `write_path` and `read_path` with `credentials` field on `S3Bucket` - [#208](https://github.com/PrefectHQ/prefect-aws/pull/208)
+
 ## 0.2.4
 
 Released on January 23rd, 2023.

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -38,6 +38,7 @@ class AwsCredentials(CredentialsBlock):
 
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/1jbV4lceHOjGgunX15lUwT/db88e184d727f721575aeb054a37e277/aws.png?h=250"  # noqa
     _block_type_name = "AWS Credentials"
+    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.AwsCredentials"  # noqa
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -166,6 +167,7 @@ class MinIOCredentials(CredentialsBlock):
         "docs: https://docs.min.io/docs/minio-server-configuration-guide.html "
         "for more info about the possible credential configurations."
     )
+    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.MinIOCredentials"  # noqa
 
     minio_root_user: str = Field(default=..., description="Admin or root user.")
     minio_root_password: SecretStr = Field(

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -269,6 +269,9 @@ class ECSTask(Infrastructure):
     _block_type_name = "ECS Task"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/1jbV4lceHOjGgunX15lUwT/db88e184d727f721575aeb054a37e277/aws.png?h=250"  # noqa
     _description = "Run a command as an ECS task."  # noqa
+    _documentation_url = (
+        "https://prefecthq.github.io/prefect-aws/ecs/#prefect_aws.ecs.ECSTask"  # noqa
+    )
 
     type: Literal["ecs-task"] = Field(
         "ecs-task", description="The slug for this task type."

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -315,9 +315,9 @@ def s3_bucket(s3, request, aws_creds_block, minio_creds_block):
     key = request.param
 
     if key == "aws_credentials":
-        fs = S3Bucket(bucket_name=BUCKET_NAME, aws_credentials=aws_creds_block)
+        fs = S3Bucket(bucket_name=BUCKET_NAME, credentials=aws_creds_block)
     elif key == "minio_credentials":
-        fs = S3Bucket(bucket_name=BUCKET_NAME, minio_credentials=minio_creds_block)
+        fs = S3Bucket(bucket_name=BUCKET_NAME, credentials=minio_creds_block)
 
     s3.create_bucket(Bucket=BUCKET_NAME)
 


### PR DESCRIPTION


<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #207

Updated tests to use `credentials` field instead of `aws_credentials` and `minio_credentials` and corrected the resulting errors.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
