### PR TITLE
Use `botocore.UNSIGNED` signature version with custom config

### DIFF
--- a/prefect_aws/client_parameters.py
+++ b/prefect_aws/client_parameters.py
@@ -3,6 +3,7 @@
 import warnings
 from typing import Any, Dict, Optional, Union
 
+from botocore import UNSIGNED
 from botocore.client import Config
 from pydantic import BaseModel, Field, FilePath, root_validator, validator
 
@@ -128,6 +129,10 @@ class AwsClientParameters(BaseModel):
                 continue
             elif key == "config":
                 params_override[key] = Config(**value)
+                # botocore UNSIGNED is an instance while actual signers can
+                # be fetched as strings
+                if params_override[key].signature_version == "unsigned":
+                    params_override[key].signature_version = UNSIGNED
             elif key == "verify_cert_path":
                 params_override["verify"] = value
             else:

--- a/tests/test_client_parameters.py
+++ b/tests/test_client_parameters.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 import pytest
+from botocore import UNSIGNED
 from botocore.client import Config
 
 from prefect_aws.client_parameters import AwsClientParameters
@@ -45,15 +46,17 @@ class TestAwsClientParameters:
         [
             (
                 AwsClientParameters(
-                    config=Config(
+                    config=dict(
                         region_name="eu_west_1",
                         retries={"max_attempts": 10, "mode": "standard"},
+                        signature_version="unsigned",
                     )
                 ),
                 {
                     "config": {
                         "region_name": "eu_west_1",
                         "retries": {"max_attempts": 10, "mode": "standard"},
+                        "signature_version": UNSIGNED,
                     },
                 },
             ),


### PR DESCRIPTION
The "signature_version" argument of `botocore.config.Config` accepts strings for signers and the `botocore.UNSIGNED` singleton when a signed should not be configured.

Change allows users to pass the `AWSCredentials` configuration {"signature_version": "unsigned"} and `prefect_aws.ClientParameters.get_params_override` will convert it to the singleton.

Also changed `TestAwsClientParameters.test_with_custom_config` test argument for `ClientParameters.config` to a dictionary since that is what it will receive from Orion.

This should probably be handled within `botocore`, but it's a quick patch for accessing some [public buckets](https://registry.opendata.aws/noaa-ghcn/).

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
