### PR TITLE
feat(ecs.py): Adding support for passing strings to the JsonPatch validator for task customizations. The deployment cli passes them as strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added string support to `JsonPatch` implementation for task customizations Link [#233](https://github.com/PrefectHQ/prefect-aws/pull/233)
+
 ### Deprecated
 
 ### Removed
@@ -213,7 +215,3 @@ Released on March 9th, 2022.
 - `read_secret` task - [#6](https://github.com/PrefectHQ/prefect-aws/pull/6)
 - `update_secret` task - [#12](https://github.com/PrefectHQ/prefect-aws/pull/12)
 - `create_secret` and `delete_secret` tasks - [#13](https://github.com/PrefectHQ/prefect-aws/pull/13)
-
-### Changed
-
-- Added string support to `JsonPatch` implementation for task customizations Link TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,3 +213,7 @@ Released on March 9th, 2022.
 - `read_secret` task - [#6](https://github.com/PrefectHQ/prefect-aws/pull/6)
 - `update_secret` task - [#12](https://github.com/PrefectHQ/prefect-aws/pull/12)
 - `create_secret` and `delete_secret` tasks - [#13](https://github.com/PrefectHQ/prefect-aws/pull/13)
+
+### Changed
+
+- Added string support to `JsonPatch` implementation for task customizations Link TBD

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -435,7 +435,7 @@ class ECSTask(Infrastructure):
             "task while it is running."
         ),
     )
-    task_customizations: Union[List[Dict], JsonPatch, str] = Field(
+    task_customizations: JsonPatch = Field(
         default_factory=lambda: JsonPatch([]),
         description="A list of JSON 6902 patches to apply to the task run request.",
     )

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -437,7 +437,10 @@ class ECSTask(Infrastructure):
     )
     task_customizations: JsonPatch = Field(
         default_factory=lambda: JsonPatch([]),
-        description="A list of JSON 6902 patches to apply to the task run request.",
+        description=(
+            "A list of JSON 6902 patches to apply to the task run request. "
+            "If a string is given, it will parsed as a JSON expression."
+        ),
     )
 
     # Execution settings

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -258,7 +258,7 @@ class ECSTask(Infrastructure):
         task_role_arn: An optional role to attach to the task run.
             This controls the permissions of the task while it is running.
         task_customizations: A list of JSON 6902 patches to apply to the task
-            run request. Can be a string to support deployment cli overrides.
+            run request. If a string is given, it will parsed as a JSON expression.
         task_start_timeout_seconds: The amount of time to watch for the
             start of the ECS task before marking it as failed. The task must
             enter a RUNNING state to be considered started.

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -862,7 +862,6 @@ async def test_execution_role_arn_in_task_definition(
 @pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize("default_cluster", [True, False])
 async def test_cluster(aws_credentials, default_cluster: bool):
-
     session = aws_credentials.get_boto3_session()
     ecs_client = session.client("ecs")
 
@@ -1535,7 +1534,9 @@ async def test_task_definition_arn_with_overrides_that_do_not_require_copy(
         create_test_ecs_cluster(ecs_client, overrides["cluster"])
         add_ec2_instance_to_ecs_cluster(session, overrides["cluster"])
 
-    task_definition_arn = ecs_client.register_task_definition(**BASE_TASK_DEFINITION,)[
+    task_definition_arn = ecs_client.register_task_definition(
+        **BASE_TASK_DEFINITION,
+    )[
         "taskDefinition"
     ]["taskDefinitionArn"]
 
@@ -1709,6 +1710,29 @@ async def test_custom_subnets_in_the_network_configuration(aws_credentials):
 
 
 @pytest.mark.usefixtures("ecs_mocks")
+async def test_task_customizations_as_string(aws_credentials):
+    tc = (
+        '[{"op": "replace", "path": "/overrides/cpu", "value": "512"}, ',
+        '{"op": "replace", "path": "/overrides/memory", "value": "1024"}]',
+    )
+
+    task = ECSTask(
+        aws_credentials=aws_credentials, memory=512, cpu=256, task_customizations=tc
+    )  # type: ignore
+
+    original_run_task = task._run_task
+    mock_run_task = MagicMock(side_effect=original_run_task)
+    task._run_task = mock_run_task
+
+    await run_then_stop_task(task)
+
+    overrides = mock_run_task.call_args[0][1].get("overrides")
+
+    assert overrides["memory"] == "1024"
+    assert overrides["cpu"] == "512"
+
+
+@pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize(
     "fields,prepare_inputs,expected_family",
     [
@@ -1844,7 +1868,6 @@ async def test_family_from_task_definition_arn(aws_credentials, prepare_for_flow
     "cluster", [None, "default", "second-cluster", "second-cluster-arn"]
 )
 async def test_kill(aws_credentials, cluster: str):
-
     session = aws_credentials.get_boto3_session()
     ecs_client = session.client("ecs")
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1534,9 +1534,7 @@ async def test_task_definition_arn_with_overrides_that_do_not_require_copy(
         create_test_ecs_cluster(ecs_client, overrides["cluster"])
         add_ec2_instance_to_ecs_cluster(session, overrides["cluster"])
 
-    task_definition_arn = ecs_client.register_task_definition(
-        **BASE_TASK_DEFINITION,
-    )[
+    task_definition_arn = ecs_client.register_task_definition(**BASE_TASK_DEFINITION,)[
         "taskDefinition"
     ]["taskDefinitionArn"]
 
@@ -1712,8 +1710,8 @@ async def test_custom_subnets_in_the_network_configuration(aws_credentials):
 @pytest.mark.usefixtures("ecs_mocks")
 async def test_task_customizations_as_string(aws_credentials):
     tc = (
-        '[{"op": "replace", "path": "/overrides/cpu", "value": "512"}, ',
-        '{"op": "replace", "path": "/overrides/memory", "value": "1024"}]',
+        '[{"op": "replace", "path": "/overrides/cpu", "value": "512"}, '
+        '{"op": "replace", "path": "/overrides/memory", "value": "1024"}]'
     )
 
     task = ECSTask(


### PR DESCRIPTION

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
This change adds support for passing strings to the task customizations parameter of the ECSTask block.  

Currently, using the cli to deploy a flow with task customizations as an infra override would result in a validation error upon flow run submission.  Examples below.

deployment command:

```bash
prefect deployment build example_flow.py:flow_1 \
        -n base \
        -sb s3/common-utils-dev-test/flow-group-1/flow-1 \
        -ib ecs-task/common-utils-flow-1-dev-test \
        --override 'task_customizations=[{"op": "replace", "path": "/overrides/cpu", "value": "512"}, {"op": "replace", "path": "/overrides/memory", "value": "1024"}]' \
        -q prefect-v2-queue-dev-test \
        -v dev \
        --params '{"param_name": "param_value"}' \
        -t common-utils -t flow-group-1 \
        -a \
        --cron '0 0 * * *'
```

prefect UI shows the following infra override:

```json
{
  "task_customizations": "[{\"op\": \"replace\", \"path\": \"/overrides/cpu\", \"value\": \"512\"}, {\"op\": \"replace\", \"path\": \"/overrides/memory\", \"value\": \"1024\"}]"
}
```

error from flow run:
```
Submission failed. pydantic.error_wrappers.ValidationError: 1 validation error for ECSTask task_customizations instance of JsonPatch expected (type=type_error.arbitrary_type; expected_arbitrary_type=JsonPatch)
```

This error was recreated by running the ECSTask block directly.

```python
test = ECSTask(
        type="ecs-task",
        task_customizations='[{"op": "replace", "path": "/overrides/cpu", "value": "512"}, {"op": "replace", "path": "/overrides/memory", "value": "1024"}]',
    )
    print(test.dict())
```

error:

```
Traceback (most recent call last):
  File "/Users/mozilla/projects/data-flows/common-utils/src/common/deployment/__init__.py", line 626, in <module>
    test = ECSTask(type='ecs-task', task_customizations="[{\"op\": \"replace\", \"path\": \"/overrides/cpu\", \"value\": \"512\"}, {\"op\": \"replace\", \"path\": \"/overrides/memory\", \"value\": \"1024\"}]")
  File "/Users/mozilla/projects/data-flows/common-utils/.venv/lib/python3.10/site-packages/prefect/blocks/core.py", line 210, in __init__
    super().__init__(*args, **kwargs)
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ECSTask
task_customizations
  instance of JsonPatch expected (type=type_error.arbitrary_type; expected_arbitrary_type=JsonPatch)
```

The changes in this PR result in a passing validation for the above test with this dictionary output.

```python
{
        "type": "ecs-task",
        "env": {},
        "labels": {},
        "name": None,
        "command": None,
        "aws_credentials": {
            "aws_access_key_id": None,
            "aws_secret_access_key": None,
            "aws_session_token": None,
            "profile_name": None,
            "region_name": None,
            "aws_client_parameters": {
                "api_version": None,
                "use_ssl": True,
                "verify": True,
                "verify_cert_path": None,
                "endpoint_url": None,
                "config": None,
            },
            "block_type_slug": "aws-credentials",
        },
        "task_definition_arn": None,
        "task_definition": None,
        "family": None,
        "image": "prefecthq/prefect:2.8.2-python3.10",
        "auto_deregister_task_definition": True,
        "cpu": None,
        "memory": None,
        "execution_role_arn": None,
        "configure_cloudwatch_logs": None,
        "cloudwatch_logs_options": {},
        "stream_output": None,
        "launch_type": "FARGATE",
        "vpc_id": None,
        "cluster": None,
        "task_role_arn": None,
        "task_customizations": [
            {"op": "replace", "path": "/overrides/cpu", "value": "512"},
            {"op": "replace", "path": "/overrides/memory", "value": "1024"},
        ],
        "task_start_timeout_seconds": 120,
        "task_watch_poll_interval": 5.0,
        "block_type_slug": "ecs-task",
    }
```

### Example
The above example should suffice.

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

Infra Overrides in UI

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/11067272/229918620-895513ff-93d3-4b08-a716-9b37650d29ce.png">

Error in UI

<img width="327" alt="image" src="https://user-images.githubusercontent.com/11067272/229918755-f0733f3d-a093-4127-ade6-095b27df6fa3.png">

Updated docs

<img width="733" alt="image" src="https://user-images.githubusercontent.com/11067272/229956240-50db201b-0ad0-4ee1-a9e1-8f588ff4ce68.png">



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [X] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
