### PR TITLE
feat(ecs.py): adding the allow_task_definition_registration boolean to offer ability to disable task definition registration handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for unsigned AWS requests - [#220](https://github.com/PrefectHQ/prefect-aws/pull/220)
 - Added push and pull project steps for S3 = [#229](https://github.com/PrefectHQ/prefect-aws/pull/229)
+- Added `allow_task_definition_registration` argument to ECSTask [#236](https://github.com/PrefectHQ/prefect-aws/pull/236)
 
 ### Changed
 

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -773,8 +773,9 @@ class ECSTask(Infrastructure):
             )
             task_definition = requested_task_definition
         else:
-            # If task registration is allowed...
-            # We must register the task definition if the arn is null or changes were made
+            # If task registration is allowed,
+            # we must register the task definition,
+            # if the arn is null or changes were made
             task_definition = self._prepare_task_definition(
                 requested_task_definition, region=ecs_client.meta.region_name
             )
@@ -789,16 +790,17 @@ class ECSTask(Infrastructure):
                     latest_task_definition, task_definition
                 ):
                     self.logger.debug(
-                        f"{self._log_prefix}: The latest task definition matches the "
-                        "required task definition; using that instead of registering a new "
-                        " one."
+                        f"{self._log_prefix}: The latest task definition "
+                        "matches the required task definition; using"
+                        "that instead of registering a new one."
                     )
                     task_definition_arn = latest_task_definition["taskDefinitionArn"]
                 else:
                     if task_definition_arn:
                         self.logger.warning(
-                            f"{self._log_prefix}: Settings require changes to the linked "
-                            "task definition. A new task definition will be registered. "
+                            f"{self._log_prefix}: Settings require changes "
+                            "to the linked task definition. A new task definition"
+                            "will be registered. "
                             + (
                                 "Enable DEBUG level logs to see the difference."
                                 if self.logger.level > logging.DEBUG

--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -765,6 +765,15 @@ class ECSTask(Infrastructure):
                     "A task_definition_arn value must be provided to "
                     "disable task definition registration"
                 )
+            container = get_prefect_container(
+                requested_task_definition.get("containerDefinitions", [{}])
+            )
+            if container is None:
+                raise ValueError(
+                    "'name' in the prefect container definition "
+                    "must be equal to PREFECT_ECS_CONTAINER_NAME"
+                )
+
             self.logger.info(
                 f"{self._log_prefix}: Task definition registration is disabled..."
             )
@@ -791,7 +800,7 @@ class ECSTask(Infrastructure):
                 ):
                     self.logger.debug(
                         f"{self._log_prefix}: The latest task definition "
-                        "matches the required task definition; using"
+                        "matches the required task definition; using "
                         "that instead of registering a new one."
                     )
                     task_definition_arn = latest_task_definition["taskDefinitionArn"]
@@ -799,7 +808,7 @@ class ECSTask(Infrastructure):
                     if task_definition_arn:
                         self.logger.warning(
                             f"{self._log_prefix}: Settings require changes "
-                            "to the linked task definition. A new task definition"
+                            "to the linked task definition. A new task definition "
                             "will be registered. "
                             + (
                                 "Enable DEBUG level logs to see the difference."

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1988,6 +1988,7 @@ async def test_allow_task_definition_registration_no_arn(aws_credentials, caplog
         )
         print(task.preview())
         task_arn = await run_then_stop_task(task)
+        print(task_arn)
     assert str(excinfo.value) == (
         "A task_definition_arn value must be provided "
         "to disable task definition registration"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #235.

Per the comment on the issue, I am adding a new argument to the ECSTask Class called `allow_task_definition_registration`.

This will default to True, but act as a way to disable the task registration logic if set to False.  This means that the task definition arn provided is the exact task definition that will be used.

This makes it so the task definition is more static and the customizations/overrides can happen on the task run only.

Task registration logic can be up the user via custom code in Python or perhaps Terraform.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

Here is an example of what the usage would look like:

```python
ecs_block = ECSTask(
            name=block_name,
            task_definition_arn=self._handle_task_definition(),
            cluster=f"prefect-v2-agent-{ENVIRONMENT_TYPE}-{DEPLOYMENT_TYPE}",
            launch_type="FARGATE",
            allow_task_definition_registration=False,
        )
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
New docs:

<img width="808" alt="image" src="https://user-images.githubusercontent.com/11067272/230198868-c063283c-0a0e-403d-9b80-b57aff3e2662.png">

Here is what the agent logs look like:

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/11067272/230399690-535f30c5-f777-4fa1-8a85-dbae87c10fa5.png">

Here is the successful flow run:

<img width="1567" alt="image" src="https://user-images.githubusercontent.com/11067272/230400101-c19ad2a6-40a6-4e14-841c-d6eac5900901.png">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
