### PR TITLE
Fixes bug where `MinIOCredentials` are not correctly resolved when used  with S3Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug where incorrect credentials model was selected when `MinIOCredentials` was used with `S3Bucket` - [#254](https://github.com/PrefectHQ/prefect-aws/pull/254)
+
 ### 0.3.1
 
 Released on April 20th, 2023.

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -265,6 +265,9 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         ),
     )
 
+    class Config:
+        smart_union = True
+
     # Property to maintain compatibility with storage block based deployments
     @property
     def basepath(self) -> str:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -585,6 +585,10 @@ class TestS3Bucket:
         )
         return _s3_bucket_with_objects
 
+    def test_credentials_are_correct_type(self, credentials):
+        s3_bucket = S3Bucket(bucket_name="bucket", credentials=credentials)
+        assert isinstance(s3_bucket.credentials, type(credentials))
+
     @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
     def test_list_objects_empty(self, s3_bucket_empty, client_parameters):
         assert s3_bucket_empty.list_objects() == []


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Enables `smart_union` on `S3Bucket` to ensure that the correct model is chosen when using `MinIOCredentials` with the `S3Bucket.credentials` field.

Closes #251 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
