### PR TITLE
Change argument to create S3Block in "Save an infrastructure and storage blocks" documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- Changed argument in getting started documentation.
 ### Deprecated
 
 ### Removed

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ s3_client.create_bucket(
 )
 s3_bucket = S3Bucket(
     bucket_name=bucket_name,
-    aws_credentials=aws_credentials,
+    credentials=aws_credentials,
 )
 s3_bucket.save(os.environ["S3_BUCKET_BLOCK_NAME"], overwrite=True)
 ```


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect-aws/issues/255#issue-1693118658

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
Changed documentation argument from 
```python
S3Bucket(
    bucket_name=bucket_name,
    aws_credentials=aws_credentials,
)
```
to
```python
S3Bucket(
    bucket_name=bucket_name,
    credentials=aws_credentials,
)
```

The original argument does not actually set the AWS credentials in the S3 Bucket Block
### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![image](https://user-images.githubusercontent.com/65039689/235980936-dd3fb480-382f-4c12-aa9d-81e8755fe4eb.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
