### PR TITLE
Updates steps to remove projects references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `prefect.projects` module. Use `prefect.deployments` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+- `prefect_aws.projects` module. Use `prefect_aws.deployments` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
 - `pull_project_from_s3` step. Use `pull_from_s3` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
 - `push_project_to_s3` step. Use `push_to_s3` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
 - `PullProjectFromS3Output` step output. Use `PullFromS3Output` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `prefect.projects` module. Use `prefect.deployments` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+- `pull_project_from_s3` step. Use `pull_from_s3` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+- `push_project_to_s3` step. Use `push_to_s3` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+- `PullProjectFromS3Output` step output. Use `PullFromS3Output` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+- `PushProjectToS3Output` step output. Use `PushToS3Output` instead. - [#278](https://github.com/PrefectHQ/prefect-aws/pull/278)
+
 ### Removed
 
 ## 0.3.3

--- a/docs/deployments/steps.md
+++ b/docs/deployments/steps.md
@@ -1,0 +1,6 @@
+---
+description: Prefect deployment steps for managing deployment code storage via AWS S3.
+notes: This documentation page is generated from source file docstrings.
+---
+
+::: prefect_aws.deployments.steps

--- a/docs/projects/steps.md
+++ b/docs/projects/steps.md
@@ -1,6 +1,0 @@
----
-description: Prefect project steps for managing project code storage via AWS S3.
-notes: This documentation page is generated from source file docstrings.
----
-
-::: prefect_aws.projects.steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,8 @@ nav:
         - Credentials: credentials.md
         - ECS Worker: ecs_worker.md
         - ECS: ecs.md
-        - Projects:
-          - Steps: projects/steps.md
+        - Deployments:
+          - Steps: deployments/steps.md
         - S3: s3.md
         - Secrets Manager: secrets_manager.md
 

--- a/prefect_aws/__init__.py
+++ b/prefect_aws/__init__.py
@@ -6,6 +6,14 @@ from .ecs import ECSTask
 from .secrets_manager import AwsSecret
 from .workers import ECSWorker
 
+from prefect._internal.compatibility.deprecated import (
+    register_renamed_module,
+)
+
+register_renamed_module(
+    "prefect_aws.projects", "prefect_aws.deployments", start_date="Jun 2023"
+)
+
 __all__ = [
     "AwsCredentials",
     "AwsClientParameters",

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -1,27 +1,29 @@
 """
-Prefect project steps for code storage and retrieval in S3 and S3 compatible services.
+Prefect deployment steps for code storage and retrieval in S3 and S3
+compatible services.
 """
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
 
 import boto3
 from botocore.client import Config
+from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 from typing_extensions import TypedDict
 
 
-class PushProjectToS3Output(TypedDict):
+class PushToS3Output(TypedDict):
     """
-    The output of the `push_project_to_s3` step.
+    The output of the `push_to_s3` step.
     """
 
     bucket: str
     folder: str
 
 
-class PullProjectFromS3Output(TypedDict):
+class PullFromS3Output(TypedDict):
     """
-    The output of the `pull_project_from_s3` step.
+    The output of the `pull_from_s3` step.
     """
 
     bucket: str
@@ -29,20 +31,25 @@ class PullProjectFromS3Output(TypedDict):
     directory: str
 
 
-def push_project_to_s3(
+@deprecated_callable(start_date="Jun 2023", help="Use `push_to_s3` instead.")
+def push_project_to_s3(*args, **kwargs):
+    push_to_s3(*args, **kwargs)
+
+
+def push_to_s3(
     bucket: str,
     folder: str,
     credentials: Optional[Dict] = None,
     client_parameters: Optional[Dict] = None,
     ignore_file: Optional[str] = ".prefectignore",
-) -> PushProjectToS3Output:
+) -> PushToS3Output:
     """
     Pushes the contents of the current working directory to an S3 bucket,
     excluding files and folders specified in the ignore_file.
 
     Args:
-        bucket: The name of the S3 bucket where the project files will be uploaded.
-        folder: The folder in the S3 bucket where the project files will be uploaded.
+        bucket: The name of the S3 bucket where files will be uploaded.
+        folder: The folder in the S3 bucket where files will be uploaded.
         credentials: A dictionary of AWS credentials (aws_access_key_id,
             aws_secret_access_key, aws_session_token).
         client_parameters: A dictionary of additional parameters to pass to the boto3
@@ -50,22 +57,22 @@ def push_project_to_s3(
         ignore_file: The name of the file containing ignore patterns.
 
     Returns:
-        A dictionary containing the bucket and folder where the project was uploaded.
+        A dictionary containing the bucket and folder where files were uploaded.
 
     Examples:
-        Push a project to an S3 bucket:
+        Push files to an S3 bucket:
         ```yaml
         build:
-            - prefect_aws.projects.steps.push_project_to_s3:
+            - prefect_aws.deployments.steps.push_to_s3:
                 requires: prefect-aws
                 bucket: my-bucket
                 folder: my-project
         ```
 
-        Push a project to an S3 bucket using credentials stored in a block:
+        Push files to an S3 bucket using credentials stored in a block:
         ```yaml
         build:
-            - prefect_aws.projects.steps.push_project_to_s3:
+            - prefect_aws.deployments.steps.push_to_s3:
                 requires: prefect-aws
                 bucket: my-bucket
                 folder: my-project
@@ -107,41 +114,46 @@ def push_project_to_s3(
     }
 
 
-def pull_project_from_s3(
+@deprecated_callable(start_date="Jun 2023", help="Use `pull_from_s3` instead.")
+def pull_project_from_s3(*args, **kwargs):
+    pull_from_s3(*args, **kwargs)
+
+
+def pull_from_s3(
     bucket: str,
     folder: str,
     credentials: Optional[Dict] = None,
     client_parameters: Optional[Dict] = None,
-) -> PullProjectFromS3Output:
+) -> PullFromS3Output:
     """
-    Pulls the contents of a project from an S3 bucket to the current working directory.
+    Pulls the contents of an S3 bucket folder to the current working directory.
 
     Args:
-        bucket: The name of the S3 bucket where the project files are stored.
-        folder: The folder in the S3 bucket where the project files are stored.
+        bucket: The name of the S3 bucket where files are stored.
+        folder: The folder in the S3 bucket where files are stored.
         credentials: A dictionary of AWS credentials (aws_access_key_id,
             aws_secret_access_key, aws_session_token).
         client_parameters: A dictionary of additional parameters to pass to the
             boto3 client.
 
     Returns:
-        A dictionary containing the bucket, folder, and local directory where the
-            project files were downloaded.
+        A dictionary containing the bucket, folder, and local directory where
+            files were downloaded.
 
     Examples:
-        Pull a project from S3 using the default credentials and client parameters:
+        Pull files from S3 using the default credentials and client parameters:
         ```yaml
         build:
-            - prefect_aws.projects.steps.pull_project_from_s3:
+            - prefect_aws.deployments.steps.pull_from_s3:
                 requires: prefect-aws
                 bucket: my-bucket
                 folder: my-project
         ```
 
-        Pull a project from S3 using credentials stored in a block:
+        Pull files from S3 using credentials stored in a block:
         ```yaml
         build:
-            - prefect_aws.projects.steps.pull_project_from_s3:
+            - prefect_aws.deployments.steps.pull_from_s3:
                 requires: prefect-aws
                 bucket: my-bucket
                 folder: my-project

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -73,7 +73,7 @@ def push_to_s3(
     Examples:
         Push files to an S3 bucket:
         ```yaml
-        build:
+        push:
             - prefect_aws.deployments.steps.push_to_s3:
                 requires: prefect-aws
                 bucket: my-bucket
@@ -82,7 +82,7 @@ def push_to_s3(
 
         Push files to an S3 bucket using credentials stored in a block:
         ```yaml
-        build:
+        push:
             - prefect_aws.deployments.steps.push_to_s3:
                 requires: prefect-aws
                 bucket: my-bucket
@@ -155,7 +155,7 @@ def pull_from_s3(
     Examples:
         Pull files from S3 using the default credentials and client parameters:
         ```yaml
-        build:
+        pull:
             - prefect_aws.deployments.steps.pull_from_s3:
                 requires: prefect-aws
                 bucket: my-bucket
@@ -164,7 +164,7 @@ def pull_from_s3(
 
         Pull files from S3 using credentials stored in a block:
         ```yaml
-        build:
+        pull:
             - prefect_aws.deployments.steps.pull_from_s3:
                 requires: prefect-aws
                 bucket: my-bucket

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -21,6 +21,11 @@ class PushToS3Output(TypedDict):
     folder: str
 
 
+@deprecated_callable(start_date="Jun 2023", help="Use `PushToS3Output` instead.")
+class PushProjectToS3Output(PushToS3Output):
+    """Deprecated. Use `PushToS3Output` instead."""
+
+
 class PullFromS3Output(TypedDict):
     """
     The output of the `pull_from_s3` step.
@@ -31,8 +36,14 @@ class PullFromS3Output(TypedDict):
     directory: str
 
 
+@deprecated_callable(start_date="Jun 2023", help="Use `PullFromS3Output` instead.")
+class PullProjectFromS3Output(PullFromS3Output):
+    """Deprecated. Use `PullFromS3Output` instead.."""
+
+
 @deprecated_callable(start_date="Jun 2023", help="Use `push_to_s3` instead.")
 def push_project_to_s3(*args, **kwargs):
+    """Deprecated. Use `push_to_s3` instead."""
     push_to_s3(*args, **kwargs)
 
 
@@ -116,6 +127,7 @@ def push_to_s3(
 
 @deprecated_callable(start_date="Jun 2023", help="Use `pull_from_s3` instead.")
 def pull_project_from_s3(*args, **kwargs):
+    """Deprecated. Use `pull_from_s3` instead."""
     pull_from_s3(*args, **kwargs)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

This PR removes references to projects in this library except in the ECS Worker guide. Updates to the ECS Worker guide need to wait until steps and CLI commands are updated in the core library.

Renames:
- `prefect.projects` -> `prefect.deployments`
- `pull_project_from_s3` -> `pull_from_s3`
- `push_project_to_s3` -> `push_to_s3`
- `PullProjectFromS3Output` -> `PullFromS3Output`
- `PushProjectToS3Output` -> `PushToS3Output`

Part of https://github.com/PrefectHQ/prefect/issues/9860

### Screenshot

![docs screenshot](https://github.com/PrefectHQ/prefect-aws/assets/12350579/364dd326-0555-4fc0-bec4-8845be02964a)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
