### PR TITLE
Fix `S3Bucket.stream_from` source path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed `S3Bucket.stream_from` path resolution - [#291](https://github.com/PrefectHQ/prefect-aws/pull/291)
+
 ### Deprecated
 
 ### Removed

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -828,7 +828,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             to_path = Path(from_path).name
 
         # Get the source object's StreamingBody
-        from_path: str = self._join_bucket_folder(from_path)
+        from_path: str = bucket._join_bucket_folder(from_path)
         from_client = bucket.credentials.get_s3_client()
         obj = await run_sync_in_worker_thread(
             from_client.get_object, Bucket=bucket.bucket_name, Key=from_path

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -623,8 +623,23 @@ class TestS3Bucket:
         return _s3_bucket
 
     @pytest.fixture
+    def s3_bucket_2_empty(self, credentials, bucket):
+        _s3_bucket = S3Bucket(
+            bucket_name="bucket",
+            credentials=credentials,
+            bucket_folder="subfolder",
+        )
+        return _s3_bucket
+
+    @pytest.fixture
     def s3_bucket_with_object(self, s3_bucket_empty, object):
         _s3_bucket_with_object = s3_bucket_empty  # object will be added
+        return _s3_bucket_with_object
+
+    @pytest.fixture
+    def s3_bucket_2_with_object(self, s3_bucket_2_empty):
+        _s3_bucket_with_object = s3_bucket_2_empty
+        s3_bucket_2_empty.write_path("object", content=b"TEST")
         return _s3_bucket_with_object
 
     @pytest.fixture
@@ -719,12 +734,12 @@ class TestS3Bucket:
     @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
     def test_stream_from(
         self,
-        s3_bucket_with_object: S3Bucket,
+        s3_bucket_2_with_object: S3Bucket,
         s3_bucket_empty: S3Bucket,
         client_parameters,
         to_path,
     ):
-        path = s3_bucket_empty.stream_from(s3_bucket_with_object, "object", to_path)
+        path = s3_bucket_empty.stream_from(s3_bucket_2_with_object, "object", to_path)
         data: bytes = s3_bucket_empty.read_path(path)
         assert data == b"TEST"
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Corrected which bucket resolves the `from_path`. Added a new test bucket fixture to `TestS3Bucket`.

Closes

#290 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
