### PR TITLE
dont break on debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed `S3Bucket.stream_from` path resolution - [#291](https://github.com/PrefectHQ/prefect-aws/pull/291)
-
 ### Deprecated
 
 ### Removed
+
+## 0.3.5
+
+### Fixed
+
+- Fixed `S3Bucket.stream_from` path resolution - [#291](https://github.com/PrefectHQ/prefect-aws/pull/291)
+- Fixed `ECSWorker` debug logs from failing to parse json - [#296](https://github.com/PrefectHQ/prefect-aws/pull/296)
 
 ## 0.3.4
 

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -675,7 +675,7 @@ class ECSWorker(BaseWorker):
         _TASK_DEFINITION_CACHE[flow_run.deployment_id] = task_definition_arn
 
         logger.info(f"Using ECS task definition {task_definition_arn!r}...")
-        logger.debug(f"Task definition {json.dumps(task_definition, indent=2)}")
+        logger.debug(f"Task definition {json.dumps(task_definition, indent=2, default=str)}")
 
         # Prepare the task run request
         task_run_request = self._prepare_task_run_request(
@@ -686,7 +686,7 @@ class ECSWorker(BaseWorker):
         )
 
         logger.info("Creating ECS task run...")
-        logger.debug(f"Task run request {json.dumps(task_run_request, indent=2)}")
+        logger.debug(f"Task run request {json.dumps(task_run_request, indent=2, default=str)}")
         try:
             task = self._create_task_run(ecs_client, task_run_request)
             task_arn = task["taskArn"]
@@ -861,7 +861,7 @@ class ECSWorker(BaseWorker):
         Returns the ARN.
         """
         logger.info("Registering ECS task definition...")
-        logger.debug(f"Task definition request {json.dumps(task_definition, indent=2)}")
+        logger.debug(f"Task definition request {json.dumps(task_definition, indent=2, default=str)}")
         response = ecs_client.register_task_definition(**task_definition)
         return response["taskDefinition"]["taskDefinitionArn"]
 

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -364,8 +364,7 @@ class ECSVariables(BaseVariables):
             "field will be slugified to match AWS character requirements."
         ),
     )
-    launch_type: Optional[
-        Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
+    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
     ] = Field(
         default=ECS_DEFAULT_LAUNCH_TYPE,
         description=(
@@ -866,7 +865,8 @@ class ECSWorker(BaseWorker):
         """
         logger.info("Registering ECS task definition...")
         logger.debug(
-            f"Task definition request {json.dumps(task_definition, indent=2, default=str)}"
+            "Task definition request"
+            f"{json.dumps(task_definition, indent=2, default=str)}"
         )
         response = ecs_client.register_task_definition(**task_definition)
         return response["taskDefinition"]["taskDefinitionArn"]
@@ -1261,7 +1261,8 @@ class ECSWorker(BaseWorker):
             )
             raise ValueError(
                 f"Failed to find {vpc_message}. "
-                "Network configuration cannot be inferred. " + help_message
+                "Network configuration cannot be inferred. "
+                + help_message
             )
 
         vpc_id = vpcs[0]["VpcId"]

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -364,15 +364,15 @@ class ECSVariables(BaseVariables):
             "field will be slugified to match AWS character requirements."
         ),
     )
-    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]] = (
-        Field(
-            default=ECS_DEFAULT_LAUNCH_TYPE,
-            description=(
-                "The type of ECS task run infrastructure that should be used. Note that"
-                " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
-                " the proper capacity provider stategy if set here."
-            ),
-        )
+    launch_type: Optional[
+        Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
+    ] = Field(
+        default=ECS_DEFAULT_LAUNCH_TYPE,
+        description=(
+            "The type of ECS task run infrastructure that should be used. Note that"
+            " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
+            " the proper capacity provider stategy if set here."
+        ),
     )
     image: Optional[str] = Field(
         default=None,
@@ -675,7 +675,9 @@ class ECSWorker(BaseWorker):
         _TASK_DEFINITION_CACHE[flow_run.deployment_id] = task_definition_arn
 
         logger.info(f"Using ECS task definition {task_definition_arn!r}...")
-        logger.debug(f"Task definition {json.dumps(task_definition, indent=2, default=str)}")
+        logger.debug(
+            f"Task definition {json.dumps(task_definition, indent=2, default=str)}"
+        )
 
         # Prepare the task run request
         task_run_request = self._prepare_task_run_request(
@@ -686,7 +688,9 @@ class ECSWorker(BaseWorker):
         )
 
         logger.info("Creating ECS task run...")
-        logger.debug(f"Task run request {json.dumps(task_run_request, indent=2, default=str)}")
+        logger.debug(
+            f"Task run request {json.dumps(task_run_request, indent=2, default=str)}"
+        )
         try:
             task = self._create_task_run(ecs_client, task_run_request)
             task_arn = task["taskArn"]
@@ -861,7 +865,9 @@ class ECSWorker(BaseWorker):
         Returns the ARN.
         """
         logger.info("Registering ECS task definition...")
-        logger.debug(f"Task definition request {json.dumps(task_definition, indent=2, default=str)}")
+        logger.debug(
+            f"Task definition request {json.dumps(task_definition, indent=2, default=str)}"
+        )
         response = ecs_client.register_task_definition(**task_definition)
         return response["taskDefinition"]["taskDefinitionArn"]
 
@@ -1255,8 +1261,7 @@ class ECSWorker(BaseWorker):
             )
             raise ValueError(
                 f"Failed to find {vpc_message}. "
-                "Network configuration cannot be inferred. "
-                + help_message
+                "Network configuration cannot be inferred. " + help_message
             )
 
         vpc_id = vpcs[0]["VpcId"]

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -364,14 +364,15 @@ class ECSVariables(BaseVariables):
             "field will be slugified to match AWS character requirements."
         ),
     )
-    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
-    ] = Field(
-        default=ECS_DEFAULT_LAUNCH_TYPE,
-        description=(
-            "The type of ECS task run infrastructure that should be used. Note that"
-            " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
-            " the proper capacity provider stategy if set here."
-        ),
+    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]] = (
+        Field(
+            default=ECS_DEFAULT_LAUNCH_TYPE,
+            description=(
+                "The type of ECS task run infrastructure that should be used. Note that"
+                " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
+                " the proper capacity provider stategy if set here."
+            ),
+        )
     )
     image: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
The retrieved task definition looks something like this:
```python
{'compatibilities': ['EC2', 'FARGATE'],
 'containerDefinitions': [{'cpu': 0,
                           'environment': [],
                           'essential': True,
                           'image': 'prefecthq/prefect:2-python3.10',
                           'mountPoints': [],
                           'name': 'prefect',
                           'portMappings': [],
                           'volumesFrom': []}],
 'cpu': '1024',
 'family': 'prefect__ecs-task-flow__ecs-task-deployment',
 'memory': '2048',
 'networkMode': 'awsvpc',
 'placementConstraints': [],
 'registeredAt': datetime.datetime(2023, 2, 23, 16, 52, 39, 140000, tzinfo=tzlocal()),
 'registeredBy': 'arn:aws:sts::576866164297:assumed-role/AWSReservedSSO_PowerUserAccess_8115307ed553845e/andrew.h@prefect.io',
 'requiresAttributes': [{'name': 'com.amazonaws.ecs.capability.docker-remote-api.1.18'},
                        {'name': 'ecs.capability.task-eni'}],
 'requiresCompatibilities': ['FARGATE'],
 'revision': 1,
 'status': 'ACTIVE',
 'taskDefinitionArn': 'arn:aws:ecs:us-east-2:576866164297:task-definition/prefect__ecs-task-flow__ecs-task-deployment:1',
 'volumes': []}

```

this can't be `json.dumps` because of the datetime. This pr changes `json.dumps` to default to str if we can't serialize