### PR TITLE
Allow custom awsvpcConfiguration for ECS Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added retries to ECS task run creation for ECS worker - [#303](https://github.com/PrefectHQ/prefect-aws/pull/303)
+- Added support to `ECSWorker` for `awsvpcConfiguration` [#304](https://github.com/PrefectHQ/prefect-aws/pull/304)
 
 ### Changed
 

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -229,6 +229,8 @@ class ECSJobConfiguration(BaseJobConfiguration):
     )
     configure_cloudwatch_logs: Optional[bool] = Field(default=None)
     cloudwatch_logs_options: Dict[str, str] = Field(default_factory=dict)
+    override_network_configuration: Optional[bool] = Field(default=None)
+    network_configuration: Dict[str, Any] = Field(default_factory=dict)
     stream_output: Optional[bool] = Field(default=None)
     task_start_timeout_seconds: int = Field(default=300)
     task_watch_poll_interval: float = Field(default=5.0)
@@ -318,6 +320,53 @@ class ECSJobConfiguration(BaseJobConfiguration):
             raise ValueError(
                 "`configure_cloudwatch_log` must be enabled to use "
                 "`cloudwatch_logs_options`."
+            )
+        return values
+
+    @root_validator
+    def network_configuration_requires_override_network_configuration(
+        cls, values: dict
+    ) -> dict:
+        """
+        Enforces that custom network configuration mode is enabled to provide custom
+        awsvpcConfiguration for network settings.
+        """
+        if values.get("network_configuration") and not values.get(
+            "override_network_configuration"
+        ):
+            raise ValueError(
+                "You must enable `override_network_configuration` to use"
+                " `network_configuration`."
+            )
+        return values
+
+    @root_validator
+    def network_configuration_requires_vpc_id(cls, values: dict) -> dict:
+        """
+        Enforces a `vpc_id` is provided when custom network configuration mode is
+        enabled for network settings.
+        """
+        if values.get("network_configuration") and not values.get("vpc_id"):
+            raise ValueError(
+                "You must provide a `vpc_id` to enable"
+                " `override_network_configuration`."
+            )
+        return values
+
+    @root_validator
+    def override_network_configuration_requires_network_configuration(
+        cls, values: dict
+    ) -> dict:
+        """
+        Enforces that awsvpcConfiguration is present when when enabling custom
+        configuration mode for network settings.
+        """
+        if not values.get("network_configuration") and values.get(
+            "override_network_configuration"
+        ):
+            raise ValueError(
+                "You must provide `network_configuration` if "
+                "`override_network_configuration` is enabled."
             )
         return values
 
@@ -459,10 +508,33 @@ class ECSVariables(BaseVariables):
             "When `configure_cloudwatch_logs` is enabled, this setting may be used to"
             " pass additional options to the CloudWatch logs configuration or override"
             " the default options. See the [AWS"
-            " documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#create_awslogs_logdriver_options.)"  # noqa
+            " documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#create_awslogs_logdriver_options)"  # noqa
             " for available options. "
         ),
     )
+
+    override_network_configuration: bool = Field(
+        default=None,
+        description=(
+            "If enabled, the Prefect container will be configured to use the"
+            " awsvpcConfiguration supplied in `network_configuration` rather than auto"
+            " generating it based on the available subnets and security groups"
+            " within the vpc. Because this is advanced configuration it is expected"
+            " that a `vpc_id` will also be provided."
+        ),
+    )
+
+    network_configuration: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "When `override_network_configuration` is enabled, this setting is applied"
+            " to the"
+            " awsvpcConfiguration that defines the ECS task executing your workload. "
+            "See the [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-awsvpcconfiguration.html)"  # noqa
+            " for available options."
+        ),
+    )
+
     stream_output: bool = Field(
         default=None,
         description=(
@@ -1242,7 +1314,7 @@ class ECSWorker(BaseWorker):
 
         return task_definition
 
-    def _load_vpc_network_config(
+    def _load_network_configuration(
         self, vpc_id: Optional[str], boto_session: boto3.Session
     ) -> dict:
         """
@@ -1289,6 +1361,47 @@ class ECSWorker(BaseWorker):
             }
         }
 
+    def _custom_network_configuration(
+        self, vpc_id: str, network_configuration: dict, boto_session: boto3.Session
+    ) -> dict:
+        """
+        Load settings from a specific VPC or the default VPC and generate a task
+        run request's network configuration.
+        """
+        ec2_client = boto_session.client("ec2")
+        vpc_message = f"VPC with ID {vpc_id}"
+
+        vpcs = ec2_client.describe_vpcs(**{"VpcIds": [vpc_id]})["Vpcs"]
+
+        if not vpcs:
+            raise ValueError(
+                f"Failed to find {vpc_message}. "
+                + "Network configuration cannot be inferred. "
+                + "Pass an explicit `vpc_id`."
+            )
+
+        vpc_id = vpcs[0]["VpcId"]
+        subnets = ec2_client.describe_subnets(
+            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+        )["Subnets"]
+
+        if not subnets:
+            raise ValueError(
+                f"Failed to find subnets for {vpc_message}. "
+                + "Network configuration cannot be inferred."
+            )
+
+        config_subnets = network_configuration.get("subnets")
+        if not all(
+            [conf_sn in sn.values() for conf_sn in config_subnets for sn in subnets]
+        ):
+            raise ValueError(
+                f"Subnets {config_subnets} not found within {vpc_message}."
+                + "Please check that VPC is associated with supplied subnets."
+            )
+
+        return {"awsvpcConfiguration": network_configuration}
+
     def _prepare_task_run_request(
         self,
         boto_session: boto3.Session,
@@ -1322,8 +1435,14 @@ class ECSWorker(BaseWorker):
         if task_definition.get("networkMode") == "awsvpc" and not task_run_request.get(
             "networkConfiguration"
         ):
-            task_run_request["networkConfiguration"] = self._load_vpc_network_config(
-                configuration.vpc_id, boto_session
+            task_run_request["networkConfiguration"] = (
+                self._load_network_configuration(configuration.vpc_id, boto_session)
+                if not configuration.override_network_configuration
+                else self._custom_network_configuration(
+                    configuration.vpc_id,
+                    configuration.network_configuration,
+                    boto_session,
+                )
             )
 
         # Ensure the container name is set if not provided at template time

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -1391,7 +1391,7 @@ class ECSWorker(BaseWorker):
                 + "Network configuration cannot be inferred."
             )
 
-        config_subnets = network_configuration.get("subnets")
+        config_subnets = network_configuration.get("subnets", [])
         if not all(
             [conf_sn in sn.values() for conf_sn in config_subnets for sn in subnets]
         ):

--- a/tests/workers/test_ecs_worker.py
+++ b/tests/workers/test_ecs_worker.py
@@ -973,56 +973,16 @@ async def test_network_config_from_custom_settings_invalid_subnet(
 
 
 @pytest.mark.usefixtures("ecs_mocks")
-async def test_network_config_configure_network_requires_config(
-    aws_credentials: AwsCredentials, flow_run: FlowRun
-):
-    with pytest.raises(
-        ValidationError,
-        match=(
-            "You must provide `network_configuration` if"
-            " `override_network_configuration` is enabled."
-        ),
-    ):
-        await construct_configuration(
-            aws_credentials=aws_credentials,
-            vpc_id="vpc-ase3456",
-            override_network_configuration=True,
-        )
-
-
-@pytest.mark.usefixtures("ecs_mocks")
 async def test_network_config_configure_network_requires_vpc_id(
     aws_credentials: AwsCredentials, flow_run: FlowRun
 ):
     with pytest.raises(
         ValidationError,
-        match="You must provide a `vpc_id` to enable `override_network_configuration`.",
+        match="You must provide a `vpc_id` to enable custom `network_configuration`.",
     ):
         await construct_configuration(
             aws_credentials=aws_credentials,
             override_network_configuration=True,
-            network_configuration={
-                "subnets": [],
-                "assignPublicIp": "ENABLED",
-                "securityGroups": [],
-            },
-        )
-
-
-@pytest.mark.usefixtures("ecs_mocks")
-async def test_network_config_requires_configure_network(
-    aws_credentials: AwsCredentials, flow_run: FlowRun
-):
-    with pytest.raises(
-        ValidationError,
-        match=(
-            "You must enable `override_network_configuration` to use"
-            " `network_configuration`."
-        ),
-    ):
-        await construct_configuration(
-            aws_credentials=aws_credentials,
-            vpc_id="vpc-ase3456",
             network_configuration={
                 "subnets": [],
                 "assignPublicIp": "ENABLED",

--- a/tests/workers/test_ecs_worker.py
+++ b/tests/workers/test_ecs_worker.py
@@ -12,6 +12,7 @@ from moto import mock_ec2, mock_ecs, mock_logs
 from moto.ec2.utils import generate_instance_identity_document
 from prefect.server.schemas.core import FlowRun
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from pydantic import ValidationError
 from tenacity import RetryError
 
 from prefect_aws.workers.ecs_worker import (
@@ -882,6 +883,111 @@ async def test_network_config_from_vpc_id(
             "securityGroups": [],
         }
     }
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_network_config_from_custom_settings(
+    aws_credentials: AwsCredentials, flow_run: FlowRun
+):
+    session = aws_credentials.get_boto3_session()
+    ec2_resource = session.resource("ec2")
+    vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2_resource.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id)
+    security_group = ec2_resource.create_security_group(
+        GroupName="ECSWorkerTestSG", Description="ECS Worker test SG", VpcId=vpc.id
+    )
+
+    configuration = await construct_configuration(
+        aws_credentials=aws_credentials,
+        vpc_id=vpc.id,
+        override_network_configuration=True,
+        network_configuration={
+            "subnets": [subnet.id],
+            "assignPublicIp": "DISABLED",
+            "securityGroups": [security_group.id],
+        },
+    )
+
+    session = aws_credentials.get_boto3_session()
+
+    async with ECSWorker(work_pool_name="test") as worker:
+        # Capture the task run call because moto does not track 'networkConfiguration'
+        original_run_task = worker._create_task_run
+        mock_run_task = MagicMock(side_effect=original_run_task)
+        worker._create_task_run = mock_run_task
+
+        result = await run_then_stop_task(worker, configuration, flow_run)
+
+    assert result.status_code == 0
+    network_configuration = mock_run_task.call_args[0][1].get("networkConfiguration")
+
+    # Subnet ids are copied from the vpc
+    assert network_configuration == {
+        "awsvpcConfiguration": {
+            "subnets": [subnet.id],
+            "assignPublicIp": "DISABLED",
+            "securityGroups": [security_group.id],
+        }
+    }
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_network_config_configure_network_requires_config(
+    aws_credentials: AwsCredentials, flow_run: FlowRun
+):
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "You must provide `network_configuration` if"
+            " `override_network_configuration` is enabled."
+        ),
+    ):
+        await construct_configuration(
+            aws_credentials=aws_credentials,
+            vpc_id="vpc-ase3456",
+            override_network_configuration=True,
+        )
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_network_config_configure_network_requires_vpc_id(
+    aws_credentials: AwsCredentials, flow_run: FlowRun
+):
+    with pytest.raises(
+        ValidationError,
+        match="You must provide a `vpc_id` to enable `override_network_configuration`.",
+    ):
+        await construct_configuration(
+            aws_credentials=aws_credentials,
+            override_network_configuration=True,
+            network_configuration={
+                "subnets": [],
+                "assignPublicIp": "ENABLED",
+                "securityGroups": [],
+            },
+        )
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+async def test_network_config_requires_configure_network(
+    aws_credentials: AwsCredentials, flow_run: FlowRun
+):
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "You must enable `override_network_configuration` to use"
+            " `network_configuration`."
+        ),
+    ):
+        await construct_configuration(
+            aws_credentials=aws_credentials,
+            vpc_id="vpc-ase3456",
+            network_configuration={
+                "subnets": [],
+                "assignPublicIp": "ENABLED",
+                "securityGroups": [],
+            },
+        )
 
 
 @pytest.mark.usefixtures("ecs_mocks")


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #298 

As per the above issue, there are cases where it is necessary to supply specific ECS Worker task configuration. This is an initial attempt to address that. As referenced in the documentation and test updates, a `dict` that supplies the settings available in the [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-awsvpcconfiguration.html)

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

Difficult to provide a code example here because these settings will likely be taken from the Work Pool configuration.

```python
ECSJobConfiguration.from_template_and_values(
    base_job_template=ECSWorker.get_default_base_job_template(),
    values={
    "aws_credentials:" aws_credentials,
    "vpc_id:" "vpc-sometest123",
    "override_network_configuration:" True,
    "network_configuration:" {
            "subnets": ["sn-sometest123"],
            "assignPublicIp": "DISABLED",
            "securityGroups": ["sg-sometest123"],
        }
    }
)
```

### Screenshots
<img width="1408" alt="image" src="https://github.com/PrefectHQ/prefect-aws/assets/10097197/fdacac4f-3694-4655-869b-feac8686635e">
<img width="1026" alt="image" src="https://github.com/PrefectHQ/prefect-aws/assets/10097197/40b8785b-aa63-4ff9-84c3-16861c443c1d">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
