### PR TITLE
Support capacity provider strategy in task run request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added retries to ECS task run creation for ECS worker - [#303](https://github.com/PrefectHQ/prefect-aws/pull/303)
 - Added support to `ECSWorker` for `awsvpcConfiguration` [#304](https://github.com/PrefectHQ/prefect-aws/pull/304)
+- Added support for a user defined `capacityProviderStrategy` in the task_run_request -[#312](https://github.com/PrefectHQ/prefect-aws/pull/312)
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Released July 20th, 2023.
 
 ### Changed
+
 - Promoted workers to GA, removed beta disclaimers
 
 ## 0.3.5
@@ -56,7 +58,7 @@ Released on June 13th, 2023.
 
 ### Fixed
 
-- Change prefect.docker import to prefect.utilities.dockerutils to fix a crash when using custom blocks based on S3Bucket  - [#273](https://github.com/PrefectHQ/prefect-aws/pull/273)
+- Change prefect.docker import to prefect.utilities.dockerutils to fix a crash when using custom blocks based on S3Bucket - [#273](https://github.com/PrefectHQ/prefect-aws/pull/273)
 
 ## 0.3.2
 
@@ -145,7 +147,7 @@ Released on January 4th, 2023.
 
 - `list_objects`, `download_object_to_path`, `download_object_to_file_object`, `download_folder_to_path`, `upload_from_path`, `upload_from_file_object`, `upload_from_folder` methods in `S3Bucket` - [#85](https://github.com/PrefectHQ/prefect-aws/pull/175)
 - `aws_client_parameters` as a field in `AwsCredentials` and `MinioCredentials` blocks - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
-- `get_client` and `get_s3_client` methods to `AwsCredentials` and `MinioCredentials` blocks  - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
+- `get_client` and `get_s3_client` methods to `AwsCredentials` and `MinioCredentials` blocks - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 
 ### Changed
 
@@ -157,7 +159,7 @@ Released on January 4th, 2023.
 
 - `endpoint_url` field in S3Bucket; specify `aws_client_parameters` in `AwsCredentials` or `MinIOCredentials` instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 - `basepath` field in S3Bucket; specify `bucket_folder` instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
-- `minio_credentials` and `aws_credentials` field in S3Bucket; use the `credentials` field instead  - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
+- `minio_credentials` and `aws_credentials` field in S3Bucket; use the `credentials` field instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 
 ## 0.2.1
 
@@ -211,6 +213,7 @@ Released on October 28th, 2022.
 - `ECSTask` is no longer experimental — [#137](https://github.com/PrefectHQ/prefect-aws/pull/137)
 
 ### Fixed
+
 - Fix ignore_file option in `S3Bucket` skipping files which should be included — [#139](https://github.com/PrefectHQ/prefect-aws/pull/139)
 - Fixed bug where `basepath` is used twice in the path when using `S3Bucket.put_directory` - [#143](https://github.com/PrefectHQ/prefect-aws/pull/143)
 

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -383,15 +383,15 @@ class ECSVariables(BaseVariables):
             "field will be slugified to match AWS character requirements."
         ),
     )
-    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]] = (
-        Field(
-            default=ECS_DEFAULT_LAUNCH_TYPE,
-            description=(
-                "The type of ECS task run infrastructure that should be used. Note that"
-                " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
-                " the proper capacity provider stategy if set here."
-            ),
-        )
+    launch_type: Optional[
+        Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
+    ] = Field(
+        default=ECS_DEFAULT_LAUNCH_TYPE,
+        description=(
+            "The type of ECS task run infrastructure that should be used. Note that"
+            " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
+            " the proper capacity provider stategy if set here."
+        ),
     )
     image: Optional[str] = Field(
         default=None,
@@ -1369,7 +1369,12 @@ class ECSWorker(BaseWorker):
         task_run_request.setdefault("taskDefinition", task_definition_arn)
         assert task_run_request["taskDefinition"] == task_definition_arn
 
-        if task_run_request.get("launchType") == "FARGATE_SPOT":
+        if "capacityProviderStrategy" in task_run_request:
+            # Should not be provided at all if capacityProviderStrategy
+            # is set, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy
+            task_run_request.pop("launchType", None)
+
+        elif task_run_request.get("launchType") == "FARGATE_SPOT":
             # Should not be provided at all for FARGATE SPOT
             task_run_request.pop("launchType", None)
 
@@ -1398,12 +1403,12 @@ class ECSWorker(BaseWorker):
             and configuration.network_configuration
             and configuration.vpc_id
         ):
-            task_run_request["networkConfiguration"] = (
-                self._custom_network_configuration(
-                    configuration.vpc_id,
-                    configuration.network_configuration,
-                    boto_session,
-                )
+            task_run_request[
+                "networkConfiguration"
+            ] = self._custom_network_configuration(
+                configuration.vpc_id,
+                configuration.network_configuration,
+                boto_session,
             )
 
         # Ensure the container name is set if not provided at template time

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -1370,8 +1370,7 @@ class ECSWorker(BaseWorker):
         assert task_run_request["taskDefinition"] == task_definition_arn
 
         if "capacityProviderStrategy" in task_run_request:
-            # Should not be provided at all if capacityProviderStrategy
-            # is set, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy
+            # Should not be provided at all if capacityProviderStrategy is set, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy  # noqa
             task_run_request.pop("launchType", None)
 
         elif task_run_request.get("launchType") == "FARGATE_SPOT":

--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -383,15 +383,15 @@ class ECSVariables(BaseVariables):
             "field will be slugified to match AWS character requirements."
         ),
     )
-    launch_type: Optional[
-        Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]
-    ] = Field(
-        default=ECS_DEFAULT_LAUNCH_TYPE,
-        description=(
-            "The type of ECS task run infrastructure that should be used. Note that"
-            " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
-            " the proper capacity provider stategy if set here."
-        ),
+    launch_type: Optional[Literal["FARGATE", "EC2", "EXTERNAL", "FARGATE_SPOT"]] = (
+        Field(
+            default=ECS_DEFAULT_LAUNCH_TYPE,
+            description=(
+                "The type of ECS task run infrastructure that should be used. Note that"
+                " 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure"
+                " the proper capacity provider stategy if set here."
+            ),
+        )
     )
     image: Optional[str] = Field(
         default=None,
@@ -1403,12 +1403,12 @@ class ECSWorker(BaseWorker):
             and configuration.network_configuration
             and configuration.vpc_id
         ):
-            task_run_request[
-                "networkConfiguration"
-            ] = self._custom_network_configuration(
-                configuration.vpc_id,
-                configuration.network_configuration,
-                boto_session,
+            task_run_request["networkConfiguration"] = (
+                self._custom_network_configuration(
+                    configuration.vpc_id,
+                    configuration.network_configuration,
+                    boto_session,
+                )
             )
 
         # Ensure the container name is set if not provided at template time

--- a/tests/workers/test_ecs_worker.py
+++ b/tests/workers/test_ecs_worker.py
@@ -1877,6 +1877,7 @@ async def test_user_defined_capacity_provider_strategy_in_task_run_request_templ
     task = describe_task(ecs_client, task_arn)
     assert task.get("capacityProviderName") == "FOO"
 
+
 @pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize(
     "cluster", [None, "default", "second-cluster", "second-cluster-arn"]

--- a/tests/workers/test_ecs_worker.py
+++ b/tests/workers/test_ecs_worker.py
@@ -1847,6 +1847,7 @@ async def test_user_defined_tags_in_task_run_request_template(
         {"key": "OVERRIDE", "value": "NEW"},
     ]
 
+
 @pytest.mark.usefixtures("ecs_mocks")
 async def test_user_defined_capacity_provider_strategy_in_task_run_request_template(
     aws_credentials: AwsCredentials, flow_run: FlowRun

--- a/tests/workers/test_ecs_worker.py
+++ b/tests/workers/test_ecs_worker.py
@@ -1874,9 +1874,7 @@ async def test_user_defined_capacity_provider_strategy_in_task_run_request_templ
     _, task_arn = parse_identifier(result.identifier)
 
     task = describe_task(ecs_client, task_arn)
-    assert task.get("capacityProviderStrategy") == [
-        {"base": 0, "weight": 1, "capacityProvider": "FOO"},
-    ]
+    assert task.get("capacityProviderName") == "FOO"
 
 @pytest.mark.usefixtures("ecs_mocks")
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

This PR allows setting a `capacityProviderStrategy` in the `task_run_request` part of an ECS Task template.  It works by checking for the `capacityProviderStrategy` key when preparing the run request and dropping the `launchType` key since these are mutually exclusive.  See:

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy

Closes https://github.com/PrefectHQ/prefect-aws/issues/310

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

The following Gist illustrates an AWS Push Work Pool template that has been modified to include a new `capacityProvider` variable, which is then used in the `capacityProviderStrategy` section of the `task_run_template`.

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
