### PR TITLE
Add as_posix to s3 push file paths in deployment step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `push_to_s3` deployment step function to write paths `as_posix()` to allow support for deploying from windows [#314](https://github.com/PrefectHQ/prefect-aws/pull/314)
+
 ### Deprecated
 
 ### Removed

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -117,7 +117,9 @@ def push_to_s3(
             continue
         elif not local_file_path.is_dir():
             remote_file_path = Path(folder) / local_file_path.relative_to(local_path)
-            client.upload_file(str(local_file_path), bucket, str(remote_file_path))
+            client.upload_file(
+                str(local_file_path), bucket, str(remote_file_path.as_posix())
+            )
 
     return {
         "bucket": bucket,

--- a/tests/deploments/test_steps.py
+++ b/tests/deploments/test_steps.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path, PurePath, PurePosixPath
 
 import boto3
@@ -46,8 +47,8 @@ def tmp_files_win(tmp_path: Path):
         "testfile1.txt",
         "testfile2.txt",
         "testfile3.txt",
-        "testdir1\\testfile4.txt",
-        "testdir2\\testfile5.txt",
+        r"testdir1\testfile4.txt",
+        r"testdir2\testfile5.txt",
     ]
 
     for file in files:
@@ -95,6 +96,7 @@ def test_push_to_s3(s3_setup, tmp_files, mock_aws_credentials):
     assert set(object_keys) == set(expected_keys)
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
 def test_push_to_s3_as_posix(s3_setup, tmp_files_win, mock_aws_credentials):
     s3, bucket_name = s3_setup
     folder = "my-project"


### PR DESCRIPTION
Add as_posix test

Completed tests

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #309 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

Now handles windows pathing appropriately as posix paths when writing to S3

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

N/A, only affects existing processing

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
