### PR TITLE
fix ssl default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.2
 
-Released October 24th, 2023.
+Released November 6th, 2023.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 0.4.2
+
+Released October 24th, 2023.
+
+### Fixed
+
+- Fixed use_ssl default for s3 client.
+
 ## 0.4.1
 
 Released October 13th, 2023.

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -220,7 +220,7 @@ def get_s3_client(
     aws_client_parameters = credentials.get("aws_client_parameters", client_parameters)
     api_version = aws_client_parameters.get("api_version", None)
     endpoint_url = aws_client_parameters.get("endpoint_url", None)
-    use_ssl = aws_client_parameters.get("use_ssl", None)
+    use_ssl = aws_client_parameters.get("use_ssl", True)
     verify = aws_client_parameters.get("verify", None)
     config_params = aws_client_parameters.get("config", {})
     config = Config(**config_params)

--- a/tests/deploments/test_steps.py
+++ b/tests/deploments/test_steps.py
@@ -228,7 +228,7 @@ def test_s3_session_with_params():
         assert {
             "api_version": "v1",
             "endpoint_url": None,
-            "use_ssl": None,
+            "use_ssl": True,
             "verify": None,
         }.items() <= all_calls[1].kwargs.items()
         assert all_calls[1].kwargs.get("config").connect_timeout == 300
@@ -244,7 +244,7 @@ def test_s3_session_with_params():
         assert {
             "api_version": None,
             "endpoint_url": None,
-            "use_ssl": None,
+            "use_ssl": True,
             "verify": None,
         }.items() <= all_calls[3].kwargs.items()
         assert all_calls[3].kwargs.get("config").connect_timeout == 60


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #327

The boto3 client parameter `use_ssl` defaults to `True`. Setting it to `None` here contradicts the default and causes uploads to SSL-only buckets to fail.
Allowing SSL only on S3 is AWS best practice https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html and therefore, this should work without the need to explicitly set use_ssl to true in the client parameters.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
