### PR TITLE
FIX use default boto args (use_ssl) for get_client

### DIFF
--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -220,7 +220,7 @@ def get_s3_client(
     aws_client_parameters = credentials.get("aws_client_parameters", client_parameters)
     api_version = aws_client_parameters.get("api_version", None)
     endpoint_url = aws_client_parameters.get("endpoint_url", None)
-    use_ssl = aws_client_parameters.get("use_ssl", None)
+    use_ssl = aws_client_parameters.get("use_ssl", True)
     verify = aws_client_parameters.get("verify", None)
     config_params = aws_client_parameters.get("config", {})
     config = Config(**config_params)

--- a/tests/deploments/test_steps.py
+++ b/tests/deploments/test_steps.py
@@ -228,7 +228,7 @@ def test_s3_session_with_params():
         assert {
             "api_version": "v1",
             "endpoint_url": None,
-            "use_ssl": None,
+            "use_ssl": True,
             "verify": None,
         }.items() <= all_calls[1].kwargs.items()
         assert all_calls[1].kwargs.get("config").connect_timeout == 300
@@ -244,7 +244,7 @@ def test_s3_session_with_params():
         assert {
             "api_version": None,
             "endpoint_url": None,
-            "use_ssl": None,
+            "use_ssl": True,
             "verify": None,
         }.items() <= all_calls[3].kwargs.items()
         assert all_calls[3].kwargs.get("config").connect_timeout == 60


### PR DESCRIPTION
A small fix to the method (introduced in https://github.com/PrefectHQ/prefect-aws/pull/322) that gets the S3 boto client that sets `use_ssl` to True; the [default client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client) uses this setting and it would be best to maintain those default settings.

I ran into this because we, by default, reject all bucket traffic that isn't encrypted.

This is small enough and it was minimal effort for me to create this PR (instead of first creating an issue); lemme know if you want an issue first.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
