### PR TITLE
fix downloading folder with same prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 0.4.3
+
+Released November 24th, 2023.
+
+### Fixed
+
+- Fix downloading folders with same prefix
+
 ## 0.4.2
 
 Released November 6th, 2023.

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -170,7 +170,7 @@ def pull_from_s3(
     s3 = get_s3_client(credentials=credentials, client_parameters=client_parameters)
 
     local_path = Path.cwd()
-
+    folder = folder.rstrip("/") + "/"
     paginator = s3.get_paginator("list_objects_v2")
     for result in paginator.paginate(Bucket=bucket, Prefix=folder):
         for obj in result.get("Contents", []):


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #342

Adds a tailing slash to folder if not present.
Ensures that only the folder is listed and not the entire prefix which could contain other folders.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [X] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
