### PR TITLE
Fix `S3Bucket.load()` for nested MinIO Credentials block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bug where `S3Bucket.load()` constructed `AwsCredentials` instead of `MinIOCredentials` - [#359](https://github.com/PrefectHQ/prefect-aws/pull/359)
+
 ### Deprecated
 
 ### Removed

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -412,7 +412,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
     bucket_name: str = Field(default=..., description="Name of your bucket.")
 
-    credentials: Union[AwsCredentials, MinIOCredentials] = Field(
+    credentials: Union[MinIOCredentials, AwsCredentials] = Field(
         default_factory=AwsCredentials,
         description="A block containing your credentials to AWS or MinIO.",
     )
@@ -424,9 +424,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             "for reading and writing objects."
         ),
     )
-
-    class Config:
-        smart_union = True
 
     # Property to maintain compatibility with storage block based deployments
     @property

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -822,7 +822,10 @@ class TestS3Bucket:
 
     def test_credentials_are_correct_type(self, credentials):
         s3_bucket = S3Bucket(bucket_name="bucket", credentials=credentials)
+        s3_bucket_parsed = S3Bucket.parse_obj({"bucket_name": "bucket", "credentials": dict(credentials)})
         assert isinstance(s3_bucket.credentials, type(credentials))
+        assert isinstance(s3_bucket_parsed.credentials, type(credentials))
+
 
     @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
     def test_list_objects_empty(self, s3_bucket_empty, client_parameters):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -822,10 +822,11 @@ class TestS3Bucket:
 
     def test_credentials_are_correct_type(self, credentials):
         s3_bucket = S3Bucket(bucket_name="bucket", credentials=credentials)
-        s3_bucket_parsed = S3Bucket.parse_obj({"bucket_name": "bucket", "credentials": dict(credentials)})
+        s3_bucket_parsed = S3Bucket.parse_obj(
+            {"bucket_name": "bucket", "credentials": dict(credentials)}
+        )
         assert isinstance(s3_bucket.credentials, type(credentials))
         assert isinstance(s3_bucket_parsed.credentials, type(credentials))
-
 
     @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
     def test_list_objects_empty(self, s3_bucket_empty, client_parameters):


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #210 

Because every field in `AwsCredentials` has a default or default factory, Pydantic considers non-matching credentials dictionaries valid and selects `AwsCredentials` when calling `S3Bucket.parse_obj()`.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
from pydantic import BaseModel, Field
from typing import Union
from prefect_aws import AwsCredentials, MinIOCredentials


class S3Bucket(BaseModel):
    bucket_name: str = Field(default=...)
    credentials: Union[AwsCredentials, MinIOCredentials] = Field(default_factory=AwsCredentials)


if __name__=="__main__":
    minio_bucket_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket",
        "credentials": {
            "minio_root_user": "Kevin",
            "minio_root_password": "password",
        }
    })

    s3_bucket_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket",
        "credentials": {
            "aws_access_key_id": "1234",
            "aws_access_key_secret": "5678",
        }
    })

    s3_bucket_no_creds_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket"
    })

    print(type(minio_bucket_parsed.credentials))
    print(type(s3_bucket_parsed.credentials))
    print(type(s3_bucket_no_creds_parsed.credentials))
```
```
<class 'prefect_aws.credentials.AwsCredentials'>
<class 'prefect_aws.credentials.AwsCredentials'>
<class 'prefect_aws.credentials.AwsCredentials'>
```

Reordered:
```python
from pydantic import BaseModel, Field
from typing import Union
from prefect_aws import AwsCredentials, MinIOCredentials


class S3Bucket(BaseModel):
    bucket_name: str = Field(default=...)
    credentials: Union[MinIOCredentials, AwsCredentials] = Field(default_factory=AwsCredentials)


if __name__=="__main__":
    minio_bucket_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket",
        "credentials": {
            "minio_root_user": "Kevin",
            "minio_root_password": "password",
        }
    })

    s3_bucket_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket",
        "credentials": {
            "aws_access_key_id": "1234",
            "aws_access_key_secret": "5678",
        }
    })

    s3_bucket_no_creds_parsed = S3Bucket.parse_obj({
        "bucket_name": "my_bucket"
    })

    print(type(minio_bucket_parsed.credentials))
    print(type(s3_bucket_parsed.credentials))
    print(type(s3_bucket_no_creds_parsed.credentials))
```

```
<class 'prefect_aws.credentials.MinIOCredentials'>
<class 'prefect_aws.credentials.AwsCredentials'>
<class 'prefect_aws.credentials.AwsCredentials'>
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
