### PR TITLE
Support MinIO Credentials block as credentials for `push_to_s3` and `pull_from_s3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support MinIO Credentials as `credentials` dict for `push_to_s3` and `pull_from_s3` - [#366](https://github.com/PrefectHQ/prefect-aws/pull/366)
+
 ### Changed
 
 ### Fixed
@@ -105,6 +107,7 @@ Released August 31st, 2023.
 Released July 20th, 2023.
 
 ### Changed
+
 - Promoted workers to GA, removed beta disclaimers
 
 ## 0.3.5
@@ -138,7 +141,7 @@ Released on June 13th, 2023.
 
 ### Fixed
 
-- Change prefect.docker import to prefect.utilities.dockerutils to fix a crash when using custom blocks based on S3Bucket  - [#273](https://github.com/PrefectHQ/prefect-aws/pull/273)
+- Change prefect.docker import to prefect.utilities.dockerutils to fix a crash when using custom blocks based on S3Bucket - [#273](https://github.com/PrefectHQ/prefect-aws/pull/273)
 
 ## 0.3.2
 
@@ -227,7 +230,7 @@ Released on January 4th, 2023.
 
 - `list_objects`, `download_object_to_path`, `download_object_to_file_object`, `download_folder_to_path`, `upload_from_path`, `upload_from_file_object`, `upload_from_folder` methods in `S3Bucket` - [#85](https://github.com/PrefectHQ/prefect-aws/pull/175)
 - `aws_client_parameters` as a field in `AwsCredentials` and `MinioCredentials` blocks - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
-- `get_client` and `get_s3_client` methods to `AwsCredentials` and `MinioCredentials` blocks  - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
+- `get_client` and `get_s3_client` methods to `AwsCredentials` and `MinioCredentials` blocks - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 
 ### Changed
 
@@ -239,7 +242,7 @@ Released on January 4th, 2023.
 
 - `endpoint_url` field in S3Bucket; specify `aws_client_parameters` in `AwsCredentials` or `MinIOCredentials` instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 - `basepath` field in S3Bucket; specify `bucket_folder` instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
-- `minio_credentials` and `aws_credentials` field in S3Bucket; use the `credentials` field instead  - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
+- `minio_credentials` and `aws_credentials` field in S3Bucket; use the `credentials` field instead - [#175](https://github.com/PrefectHQ/prefect-aws/pull/175)
 
 ## 0.2.1
 
@@ -293,6 +296,7 @@ Released on October 28th, 2022.
 - `ECSTask` is no longer experimental — [#137](https://github.com/PrefectHQ/prefect-aws/pull/137)
 
 ### Fixed
+
 - Fix ignore_file option in `S3Bucket` skipping files which should be included — [#139](https://github.com/PrefectHQ/prefect-aws/pull/139)
 - Fixed bug where `basepath` is used twice in the path when using `S3Bucket.put_directory` - [#143](https://github.com/PrefectHQ/prefect-aws/pull/143)
 

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -206,12 +206,12 @@ def get_s3_client(
         client_parameters = {}
 
     # Get credentials from credentials (regardless if block or not)
-    aws_access_key_id = credentials.get("aws_access_key_id", None) or credentials.get(
-        "minio_root_user", None
+    aws_access_key_id = credentials.get(
+        "aws_access_key_id", credentials.get("minio_root_user", None)
     )
     aws_secret_access_key = credentials.get(
-        "aws_secret_access_key", None
-    ) or credentials.get("minio_root_password", None)
+        "aws_secret_access_key", credentials.get("minio_root_password", None)
+    )
     aws_session_token = credentials.get("aws_session_token", None)
 
     # Get remaining session info from credentials, or client_parameters

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -204,8 +204,12 @@ def get_s3_client(
         client_parameters = {}
 
     # Get credentials from credentials (regardless if block or not)
-    aws_access_key_id = credentials.get("aws_access_key_id", None)
-    aws_secret_access_key = credentials.get("aws_secret_access_key", None)
+    aws_access_key_id = credentials.get("aws_access_key_id", None) or credentials.get(
+        "minio_root_user", None
+    )
+    aws_secret_access_key = credentials.get(
+        "aws_secret_access_key", None
+    ) or credentials.get("minio_root_password", None)
     aws_session_token = credentials.get("aws_session_token", None)
 
     # Get remaining session info from credentials, or client_parameters

--- a/prefect_aws/deployments/steps.py
+++ b/prefect_aws/deployments/steps.py
@@ -62,7 +62,8 @@ def push_to_s3(
         bucket: The name of the S3 bucket where files will be uploaded.
         folder: The folder in the S3 bucket where files will be uploaded.
         credentials: A dictionary of AWS credentials (aws_access_key_id,
-            aws_secret_access_key, aws_session_token).
+            aws_secret_access_key, aws_session_token) or MinIO credentials
+            (minio_root_user, minio_root_password).
         client_parameters: A dictionary of additional parameters to pass to the boto3
             client.
         ignore_file: The name of the file containing ignore patterns.
@@ -139,7 +140,8 @@ def pull_from_s3(
         bucket: The name of the S3 bucket where files are stored.
         folder: The folder in the S3 bucket where files are stored.
         credentials: A dictionary of AWS credentials (aws_access_key_id,
-            aws_secret_access_key, aws_session_token).
+            aws_secret_access_key, aws_session_token) or MinIO credentials
+            (minio_root_user, minio_root_password).
         client_parameters: A dictionary of additional parameters to pass to the
             boto3 client.
 

--- a/tests/deployments/test_steps.py
+++ b/tests/deployments/test_steps.py
@@ -10,7 +10,15 @@ from moto import mock_s3
 from prefect_aws import AwsCredentials
 from prefect_aws.deployments.steps import get_s3_client, pull_from_s3, push_to_s3
 
-os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "http://custom.minio.endpoint:9000"
+
+@pytest.fixture(scope="module", autouse=True)
+def set_custom_endpoint():
+    original = os.environ.get("MOTO_S3_CUSTOM_ENDPOINTS")
+    os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "http://custom.minio.endpoint:9000"
+    yield
+    os.environ.pop("MOTO_S3_CUSTOM_ENDPOINTS")
+    if original is not None:
+        os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = original
 
 
 @pytest.fixture

--- a/tests/deployments/test_steps.py
+++ b/tests/deployments/test_steps.py
@@ -10,6 +10,8 @@ from moto import mock_s3
 from prefect_aws import AwsCredentials
 from prefect_aws.deployments.steps import get_s3_client, pull_from_s3, push_to_s3
 
+os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "http://custom.minio.endpoint:9000"
+
 
 @pytest.fixture
 def s3_setup():
@@ -215,8 +217,15 @@ def test_s3_session_with_params():
             },
         )
         get_s3_client(credentials=creds_block.dict())
+        get_s3_client(
+            credentials={
+                "minio_root_user": "MY_USER",
+                "minio_root_password": "MY_PASSWORD",
+            },
+            client_parameters={"endpoint_url": "http://custom.minio.endpoint:9000"},
+        )
         all_calls = mock_session.mock_calls
-        assert len(all_calls) == 6
+        assert len(all_calls) == 8
         assert all_calls[0].kwargs == {
             "aws_access_key_id": "THE_KEY",
             "aws_secret_access_key": "SHHH!",
@@ -265,6 +274,20 @@ def test_s3_session_with_params():
         }.items() <= all_calls[5].kwargs.items()
         assert all_calls[5].kwargs.get("config").connect_timeout == 123
         assert all_calls[5].kwargs.get("config").signature_version is None
+        assert all_calls[6].kwargs == {
+            "aws_access_key_id": "MY_USER",
+            "aws_secret_access_key": "MY_PASSWORD",
+            "aws_session_token": None,
+            "profile_name": None,
+            "region_name": None,
+        }
+        assert all_calls[7].args[0] == "s3"
+        assert {
+            "api_version": None,
+            "use_ssl": True,
+            "verify": None,
+            "endpoint_url": "http://custom.minio.endpoint:9000",
+        }.items() <= all_calls[7].kwargs.items()
 
 
 def test_custom_credentials_and_client_parameters(s3_setup, tmp_files):
@@ -280,6 +303,47 @@ def test_custom_credentials_and_client_parameters(s3_setup, tmp_files):
     custom_client_parameters = {
         "region_name": "us-west-1",
         "config": {"signature_version": "s3v4"},
+    }
+
+    os.chdir(tmp_files)
+
+    # Test push_to_s3 with custom credentials and client parameters
+    push_to_s3(
+        bucket_name,
+        folder,
+        credentials=custom_credentials,
+        client_parameters=custom_client_parameters,
+    )
+
+    # Test pull_from_s3 with custom credentials and client parameters
+    tmp_path = tmp_files / "test_pull"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    os.chdir(tmp_path)
+
+    pull_from_s3(
+        bucket_name,
+        folder,
+        credentials=custom_credentials,
+        client_parameters=custom_client_parameters,
+    )
+
+    for file in tmp_files.iterdir():
+        if file.is_file() and file.name != ".prefectignore":
+            assert (tmp_path / file.name).exists()
+
+
+def test_custom_credentials_and_client_parameters_minio(s3_setup, tmp_files):
+    s3, bucket_name = s3_setup
+    folder = "my-project"
+
+    # Custom credentials and client parameters
+    custom_credentials = {
+        "minio_root_user": "fake_user",
+        "minio_root_password": "fake_password",
+    }
+
+    custom_client_parameters = {
+        "endpoint_url": "http://custom.minio.endpoint:9000",
     }
 
     os.chdir(tmp_files)


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

When using `prefect.yaml`, allows the user to supply a MinIO Credentials block name for the `push_to_s3` and `pull_from_s3` deployment steps.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```yaml
build: null

push:
  - prefect_aws.deployments.steps.push_to_s3:
      bucket: test
      folder: my-project
      credentials: "{{ prefect.blocks.minio-credentials.test-creds }}"

pull:
  - prefect_aws.deployments.steps.pull_from_s3:
      bucket: test
      folder: my-project
      credentials: "{{ prefect.blocks.minio-credentials.test-creds }}"

deployments:
  - name: minio-stored-deployment
    entrypoint: flow.py:my_minio_flow
    work_pool:
      name: my-ecs-pool
    is_schedule_active: true
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
<img width="929" alt="image" src="https://github.com/PrefectHQ/prefect-aws/assets/146098880/82baee1f-e7cc-4ce0-ab34-629372b8b751">
<img width="1196" alt="image" src="https://github.com/PrefectHQ/prefect-aws/assets/146098880/58e067bb-c81c-4d3c-9971-d93bbd29fe3f">

Docstring update for `push_to_s3` and `pull_from_s3`:
![image](https://github.com/PrefectHQ/prefect-aws/assets/146098880/b766843d-c6c2-4ad0-a781-79ffe3a560be)



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
