### PR TITLE
provide ability to cache boto client instances directly and on `S3Bucket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Handle `boto3` clients more efficiently with `lru_cache` - [#361](https://github.com/PrefectHQ/prefect-aws/pull/361)
+
 ### Fixed
 
 - Bug where `S3Bucket.load()` constructed `AwsCredentials` instead of `MinIOCredentials` - [#359](https://github.com/PrefectHQ/prefect-aws/pull/359)
@@ -95,6 +97,7 @@ Released August 31st, 2023.
 Released July 20th, 2023.
 
 ### Changed
+
 - Promoted workers to GA, removed beta disclaimers
 
 ## 0.3.5
@@ -283,6 +286,7 @@ Released on October 28th, 2022.
 - `ECSTask` is no longer experimental — [#137](https://github.com/PrefectHQ/prefect-aws/pull/137)
 
 ### Fixed
+
 - Fix ignore_file option in `S3Bucket` skipping files which should be included — [#139](https://github.com/PrefectHQ/prefect-aws/pull/139)
 - Fixed bug where `basepath` is used twice in the path when using `S3Bucket.put_directory` - [#143](https://github.com/PrefectHQ/prefect-aws/pull/143)
 

--- a/prefect_aws/client_parameters.py
+++ b/prefect_aws/client_parameters.py
@@ -70,6 +70,18 @@ class AwsClientParameters(BaseModel):
         title="Botocore Config",
     )
 
+    def __hash__(self):
+        return hash(
+            (
+                self.api_version,
+                self.use_ssl,
+                self.verify,
+                self.verify_cert_path,
+                self.endpoint_url,
+                self.config,
+            )
+        )
+
     @validator("config", pre=True)
     def instantiate_config(cls, value: Union[Config, Dict[str, Any]]) -> Dict[str, Any]:
         """

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -27,7 +27,7 @@ class ClientType(Enum):
     SECRETS_MANAGER = "secretsmanager"
 
 
-@lru_cache
+@lru_cache(maxsize=8, typed=True)
 def _get_client_cached(ctx, client_type: Union[str, ClientType]) -> Any:
     """
     Helper method to cache and dynamically get a client type.
@@ -103,7 +103,7 @@ class AwsCredentials(CredentialsBlock):
     )
 
     class Config:
-        """pydantic config"""
+        """Config class for pydantic model."""
 
         arbitrary_types_allowed = True
 
@@ -216,7 +216,7 @@ class MinIOCredentials(CredentialsBlock):
     )
 
     class Config:
-        """pydantic config"""
+        """Config class for pydantic model."""
 
         arbitrary_types_allowed = True
 

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -148,7 +148,7 @@ class AwsCredentials(CredentialsBlock):
             region_name=self.region_name,
         )
 
-    def get_client(self, client_type: Union[str, ClientType]) -> Any:
+    def get_client(self, client_type: Union[str, ClientType], use_cache: bool = False):
         """
         Helper method to dynamically get a client type.
 
@@ -161,6 +161,15 @@ class AwsCredentials(CredentialsBlock):
         Raises:
             ValueError: if the client is not supported.
         """
+        if isinstance(client_type, ClientType):
+            client_type = client_type.value
+
+        if not use_cache:
+            return self.get_boto3_session().client(
+                service_name=client_type,
+                **self.aws_client_parameters.get_params_override()
+            )
+    
         return _get_client_cached(ctx=self, client_type=client_type)
 
     def get_s3_client(self) -> S3Client:
@@ -271,7 +280,7 @@ class MinIOCredentials(CredentialsBlock):
             region_name=self.region_name,
         )
 
-    def get_client(self, client_type: Union[str, ClientType]) -> Any:
+    def get_client(self, client_type: Union[str, ClientType], use_cache: bool = False):
         """
         Helper method to dynamically get a client type.
 
@@ -284,6 +293,15 @@ class MinIOCredentials(CredentialsBlock):
         Raises:
             ValueError: if the client is not supported.
         """
+        if isinstance(client_type, ClientType):
+            client_type = client_type.value
+
+        if not use_cache:
+            return self.get_boto3_session().client(
+                service_name=client_type,
+                **self.aws_client_parameters.get_params_override()
+            )
+    
         return _get_client_cached(ctx=self, client_type=client_type)
 
     def get_s3_client(self) -> S3Client:

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -108,8 +108,7 @@ class AwsCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return id(self)
-        # return hash(self.json())
+        return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """
@@ -222,8 +221,7 @@ class MinIOCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return id(self)
-        # return hash(self.json())
+        return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -75,6 +75,8 @@ class AwsCredentials(CredentialsBlock):
         title="AWS Client Parameters",
     )
 
+    _s3_client: Optional[S3Client] = None
+
     def get_boto3_session(self) -> boto3.Session:
         """
         Returns an authenticated boto3 session that can be used to create clients
@@ -132,7 +134,12 @@ class AwsCredentials(CredentialsBlock):
         Returns:
             An authenticated S3 client.
         """
-        return self.get_client(client_type=ClientType.S3)
+        if self._s3_client is not None:
+            return self._s3_client
+
+        self._s3_client = self.get_client(client_type=ClientType.S3)
+
+        return self._s3_client
 
     def get_secrets_manager_client(self) -> SecretsManagerClient:
         """

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -238,10 +238,10 @@ class MinIOCredentials(CredentialsBlock):
     def __hash__(self):
         return hash(
             (
-                self.minio_root_user,
-                self.minio_root_password,
-                self.region_name,
-                self.aws_client_parameters,
+                hash(self.minio_root_user),
+                hash(self.minio_root_password),
+                hash(self.region_name),
+                hash(frozenset(self.aws_client_parameters.dict().items())),
             )
         )
 

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -30,7 +30,7 @@ class ClientType(Enum):
 @lru_cache
 def _get_client_cached(ctx, client_type: Union[str, ClientType]) -> Any:
     """
-    Helper method to cache and  dynamically get a client type.
+    Helper method to cache and dynamically get a client type.
 
     Args:
         client_type: The client's service name.

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -108,7 +108,7 @@ class AwsCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return id(self)
+        return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """
@@ -221,7 +221,7 @@ class MinIOCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return id(self)
+        return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -167,9 +167,9 @@ class AwsCredentials(CredentialsBlock):
         if not use_cache:
             return self.get_boto3_session().client(
                 service_name=client_type,
-                **self.aws_client_parameters.get_params_override()
+                **self.aws_client_parameters.get_params_override(),
             )
-    
+
         return _get_client_cached(ctx=self, client_type=client_type)
 
     def get_s3_client(self) -> S3Client:
@@ -299,9 +299,9 @@ class MinIOCredentials(CredentialsBlock):
         if not use_cache:
             return self.get_boto3_session().client(
                 service_name=client_type,
-                **self.aws_client_parameters.get_params_override()
+                **self.aws_client_parameters.get_params_override(),
             )
-    
+
         return _get_client_cached(ctx=self, client_type=client_type)
 
     def get_s3_client(self) -> S3Client:

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -108,7 +108,16 @@ class AwsCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return hash(self.json())
+        return hash(
+            (
+                self.aws_access_key_id,
+                self.aws_secret_access_key,
+                self.aws_session_token,
+                self.profile_name,
+                self.region_name,
+                self.aws_client_parameters,
+            )
+        )
 
     def get_boto3_session(self) -> boto3.Session:
         """
@@ -221,7 +230,14 @@ class MinIOCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return hash(self.json())
+        return hash(
+            (
+                self.minio_root_user,
+                self.minio_root_password,
+                self.region_name,
+                self.aws_client_parameters,
+            )
+        )
 
     def get_boto3_session(self) -> boto3.Session:
         """

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -19,7 +19,7 @@ from prefect_aws.client_parameters import AwsClientParameters
 
 
 class ClientType(Enum):
-    """Boto3 Client Types"""
+    """The supported boto3 clients."""
 
     S3 = "s3"
     ECS = "ecs"

--- a/prefect_aws/credentials.py
+++ b/prefect_aws/credentials.py
@@ -108,7 +108,8 @@ class AwsCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return hash(self.json())
+        return id(self)
+        # return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """
@@ -221,7 +222,8 @@ class MinIOCredentials(CredentialsBlock):
         arbitrary_types_allowed = True
 
     def __hash__(self):
-        return hash(self.json())
+        return id(self)
+        # return hash(self.json())
 
     def get_boto3_session(self) -> boto3.Session:
         """

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -424,6 +424,15 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             "for reading and writing objects."
         ),
     )
+    
+    cache_client: bool = Field(
+        default=False,
+        description=(
+            "If True, the S3 client will be cached. This is useful for "
+            "performance, but can cause issues if the S3 client is used "
+            "in multiple threads."
+        ),
+    )
 
     # Property to maintain compatibility with storage block based deployments
     @property
@@ -466,7 +475,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         Authenticate MinIO credentials or AWS credentials and return an S3 client.
         This is a helper function called by read_path() or write_path().
         """
-        return self.credentials.get_s3_client()
+        return self.credentials.get_client("s3", use_cache=self.cache_client)
 
     def _get_bucket_resource(self) -> boto3.resource:
         """

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -670,8 +670,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         object.
         """
 
-        s3_client = self._get_s3_client()
-
         with io.BytesIO(data) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=self.bucket_name, Key=key)
 

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -424,7 +424,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             "for reading and writing objects."
         ),
     )
-    
+
     cache_client: bool = Field(
         default=False,
         description=(

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -425,15 +425,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         ),
     )
 
-    cache_client: bool = Field(
-        default=False,
-        description=(
-            "If True, the S3 client will be cached. This is useful for "
-            "performance, but could cause issues if the S3 client is used "
-            "in multi-threaded environments."
-        ),
-    )
-
     # Property to maintain compatibility with storage block based deployments
     @property
     def basepath(self) -> str:
@@ -475,7 +466,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         Authenticate MinIO credentials or AWS credentials and return an S3 client.
         This is a helper function called by read_path() or write_path().
         """
-        return self.credentials.get_client("s3", use_cache=self.cache_client)
+        return self.credentials.get_client("s3")
 
     def _get_bucket_resource(self) -> boto3.resource:
         """

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -429,8 +429,8 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         default=False,
         description=(
             "If True, the S3 client will be cached. This is useful for "
-            "performance, but can cause issues if the S3 client is used "
-            "in multiple threads."
+            "performance, but could cause issues if the S3 client is used "
+            "in multi-threaded environments."
         ),
     )
 

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -569,7 +569,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
                     remote_file_path.as_posix(), content=local_file_content
                 )
                 uploaded_file_count += 1
-                print(uploaded_file_count)  # TODO remove print
 
         return uploaded_file_count
 

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -551,8 +551,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
             included_files = filter_files(local_path, ignore_patterns)
 
-        s3_client = self._get_s3_client()
-
         uploaded_file_count = 0
         for local_file_path in Path(local_path).expanduser().rglob("*"):
             if (
@@ -568,9 +566,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
                     local_file_content = local_file.read()
 
                 await self.write_path(
-                    s3_client,
-                    remote_file_path.as_posix(),
-                    content=local_file_content,
+                    remote_file_path.as_posix(), content=local_file_content
                 )
                 uploaded_file_count += 1
                 print(uploaded_file_count)  # TODO remove print
@@ -625,9 +621,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             return output
 
     @sync_compatible
-    async def write_path(
-        self, s3_client: boto3.client, path: str, content: bytes
-    ) -> str:
+    async def write_path(self, path: str, content: bytes) -> str:
         """
         Writes to an S3 bucket.
 
@@ -661,15 +655,17 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
         path = self._resolve_path(path)
 
-        await run_sync_in_worker_thread(self._write_sync, s3_client, path, content)
+        await run_sync_in_worker_thread(self._write_sync, path, content)
 
         return path
 
-    def _write_sync(self, s3_client: boto3.client, key: str, data: bytes) -> None:
+    def _write_sync(self, key: str, data: bytes) -> None:
         """
         Called by write_path(). Creates an S3 client and uploads a file
         object.
         """
+
+        s3_client = self._get_s3_client()
 
         with io.BytesIO(data) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=self.bucket_name, Key=key)

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -573,6 +573,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
                     content=local_file_content,
                 )
                 uploaded_file_count += 1
+                print(uploaded_file_count)  # TODO remove print
 
         return uploaded_file_count
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,9 +1,16 @@
+from unittest.mock import patch
+
 import pytest
 from boto3.session import Session
 from botocore.client import BaseClient
 from moto import mock_s3
 
-from prefect_aws.credentials import AwsCredentials, ClientType, MinIOCredentials
+from prefect_aws.credentials import (
+    AwsCredentials,
+    ClientType,
+    MinIOCredentials,
+    _get_client_cached,
+)
 
 
 def test_aws_credentials_get_boto3_session():
@@ -44,3 +51,27 @@ def test_minio_credentials_get_boto3_session():
 def test_credentials_get_client(credentials, client_type):
     with mock_s3():
         assert isinstance(credentials.get_client(client_type), BaseClient)
+
+
+@patch("prefect_aws.credentials._get_client_cached")
+def test_get_client_cached(mock_get_client_cached):
+    """
+    Test to ensure that _get_client_cached function returns the same instance
+    for multiple calls with the same parameters and properly utilizes lru_cache.
+    """
+
+    # Create a mock AwsCredentials instance
+    aws_credentials_block = AwsCredentials()
+
+    # Call _get_client_cached multiple times with the same parameters
+    _get_client_cached(aws_credentials_block, ClientType.S3)
+    _get_client_cached(aws_credentials_block, ClientType.S3)
+
+    # Verify that _get_client_cached is called only once due to caching
+    mock_get_client_cached.assert_called_once_with(aws_credentials_block, ClientType.S3)
+
+    # Test with different parameters to ensure they are cached separately
+    _get_client_cached(aws_credentials_block, ClientType.ECS)
+    assert (
+        mock_get_client_cached.call_count == 2
+    ), "Should be called twice with different parameters"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -50,9 +50,8 @@ def test_credentials_get_client(credentials, client_type):
     with mock_s3():
         assert isinstance(credentials.get_client(client_type), BaseClient)
 
-@pytest.mark.parametrize(
-    "client_type", [member.value for member in ClientType]
-)
+
+@pytest.mark.parametrize("client_type", [member.value for member in ClientType])
 def test_get_client_cached(client_type):
     """
     Test to ensure that _get_client_cached function returns the same instance
@@ -68,7 +67,7 @@ def test_get_client_cached(client_type):
     assert _get_client_cached.cache_info().hits == 0, "Initial call count should be 0"
 
     assert aws_credentials_block.get_client(client_type) is not None
-    
+
     assert _get_client_cached.cache_info().hits == 0, "Cache should not yet be used"
 
     # Call get_client multiple times with the same parameters

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,7 +3,12 @@ from boto3.session import Session
 from botocore.client import BaseClient
 from moto import mock_s3
 
-from prefect_aws.credentials import AwsCredentials, ClientType, MinIOCredentials
+from prefect_aws.credentials import (
+    AwsCredentials,
+    ClientType,
+    MinIOCredentials,
+    _get_client_cached,
+)
 
 
 def test_aws_credentials_get_boto3_session():
@@ -41,6 +46,68 @@ def test_minio_credentials_get_boto3_session():
     ],
 )
 @pytest.mark.parametrize("client_type", ["s3", ClientType.S3])
-def test_credentials_get_client(credentials, client_type):
+def test_credentials_get_client_s3(credentials, client_type):
     with mock_s3():
         assert isinstance(credentials.get_client(client_type), BaseClient)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        AwsCredentials(),
+        MinIOCredentials(
+            minio_root_user="root_user", minio_root_password="root_password"
+        ),
+    ],
+)
+@pytest.mark.parametrize("client_type", ["ecs", ClientType.ECS])
+def test_credentials_get_client_ecs(credentials, client_type):
+    with mock_s3():
+        assert isinstance(credentials.get_client(client_type), BaseClient)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        AwsCredentials(),
+        MinIOCredentials(
+            minio_root_user="root_user", minio_root_password="root_password"
+        ),
+    ],
+)
+@pytest.mark.parametrize("client_type", ["batch", ClientType.BATCH])
+def test_credentials_get_client_batch(credentials, client_type):
+    with mock_s3():
+        assert isinstance(credentials.get_client(client_type), BaseClient)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        AwsCredentials(),
+        MinIOCredentials(
+            minio_root_user="root_user", minio_root_password="root_password"
+        ),
+    ],
+)
+@pytest.mark.parametrize("client_type", ["s3", ClientType.S3])
+def test_credentials_get_client_cached_s3(credentials, client_type):
+    with mock_s3():
+        assert isinstance(_get_client_cached(credentials, client_type), BaseClient)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        AwsCredentials(),
+        MinIOCredentials(
+            minio_root_user="root_user", minio_root_password="root_password"
+        ),
+    ],
+)
+@pytest.mark.parametrize("client_type", ["ecs", ClientType.ECS])
+def test_credentials_get_client_cached_ecs(credentials, client_type):
+    with mock_s3():
+        client = _get_client_cached(credentials, client_type)
+
+        assert isinstance(client, BaseClient)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,113 +1,249 @@
-import pytest
-from boto3.session import Session
-from botocore.client import BaseClient
-from moto import mock_s3
+"""Module handling AWS credentials"""
 
-from prefect_aws.credentials import (
-    AwsCredentials,
-    ClientType,
-    MinIOCredentials,
-    _get_client_cached,
-)
+from enum import Enum
+from typing import Any, Optional, Union
+
+import boto3
+from mypy_boto3_s3 import S3Client
+from mypy_boto3_secretsmanager import SecretsManagerClient
+from prefect.blocks.abstract import CredentialsBlock
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
+
+from prefect_aws.client_parameters import AwsClientParameters
 
 
-def test_aws_credentials_get_boto3_session():
+class ClientType(Enum):
+    S3 = "s3"
+    ECS = "ecs"
+    BATCH = "batch"
+    SECRETS_MANAGER = "secretsmanager"
+
+
+class AwsCredentials(CredentialsBlock):
     """
-    Asserts that instantiated AwsCredentials block creates an
-    authenticated boto3 session.
-    """
+    Block used to manage authentication with AWS. AWS authentication is
+    handled via the `boto3` module. Refer to the
+    [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
+    for more info about the possible credential configurations.
 
-    with mock_s3():
-        aws_credentials_block = AwsCredentials()
-        boto3_session = aws_credentials_block.get_boto3_session()
-        assert isinstance(boto3_session, Session)
+    Example:
+        Load stored AWS credentials:
+        ```python
+        from prefect_aws import AwsCredentials
 
+        aws_credentials_block = AwsCredentials.load("BLOCK_NAME")
+        ```
+    """  # noqa E501
 
-def test_minio_credentials_get_boto3_session():
-    """
-    Asserts that instantiated MinIOCredentials block creates
-    an authenticated boto3 session.
-    """
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/d74b16fe84ce626345adf235a47008fea2869a60-225x225.png"  # noqa
+    _block_type_name = "AWS Credentials"
+    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.AwsCredentials"  # noqa
 
-    minio_credentials_block = MinIOCredentials(
-        minio_root_user="root_user", minio_root_password="root_password"
+    aws_access_key_id: Optional[str] = Field(
+        default=None,
+        description="A specific AWS access key ID.",
+        title="AWS Access Key ID",
     )
-    boto3_session = minio_credentials_block.get_boto3_session()
-    assert isinstance(boto3_session, Session)
-
-
-@pytest.mark.parametrize(
-    "credentials",
-    [
-        AwsCredentials(),
-        MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
+    aws_secret_access_key: Optional[SecretStr] = Field(
+        default=None,
+        description="A specific AWS secret access key.",
+        title="AWS Access Key Secret",
+    )
+    aws_session_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "The session key for your AWS account. "
+            "This is only needed when you are using temporary credentials."
         ),
-    ],
-)
-@pytest.mark.parametrize("client_type", ["s3", ClientType.S3])
-def test_credentials_get_client_s3(credentials, client_type):
-    with mock_s3():
-        assert isinstance(credentials.get_client(client_type), BaseClient)
+        title="AWS Session Token",
+    )
+    profile_name: Optional[str] = Field(
+        default=None, description="The profile to use when creating your session."
+    )
+    region_name: Optional[str] = Field(
+        default=None,
+        description="The AWS Region where you want to create new connections.",
+    )
+    aws_client_parameters: AwsClientParameters = Field(
+        default_factory=AwsClientParameters,
+        description="Extra parameters to initialize the Client.",
+        title="AWS Client Parameters",
+    )
+
+    def get_boto3_session(self) -> boto3.Session:
+        """
+        Returns an authenticated boto3 session that can be used to create clients
+        for AWS services
+
+        Example:
+            Create an S3 client from an authorized boto3 session:
+            ```python
+            aws_credentials = AwsCredentials(
+                aws_access_key_id = "access_key_id",
+                aws_secret_access_key = "secret_access_key"
+                )
+            s3_client = aws_credentials.get_boto3_session().client("s3")
+            ```
+        """
+
+        if self.aws_secret_access_key:
+            aws_secret_access_key = self.aws_secret_access_key.get_secret_value()
+        else:
+            aws_secret_access_key = None
+
+        return boto3.Session(
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
+            profile_name=self.profile_name,
+            region_name=self.region_name,
+        )
+
+    def get_client(self, client_type: Union[str, ClientType]) -> Any:
+        """
+        Helper method to dynamically get a client type.
+
+        Args:
+            client_type: The client's service name.
+
+        Returns:
+            An authenticated client.
+
+        Raises:
+            ValueError: if the client is not supported.
+        """
+        if isinstance(client_type, ClientType):
+            client_type = client_type.value
+
+        client = self.get_boto3_session().client(
+            service_name=client_type, **self.aws_client_parameters.get_params_override()
+        )
+        return client
+
+    def get_s3_client(self) -> S3Client:
+        """
+        Gets an authenticated S3 client.
+
+        Returns:
+            An authenticated S3 client.
+        """
+        return self.get_client(client_type=ClientType.S3)
+
+    def get_secrets_manager_client(self) -> SecretsManagerClient:
+        """
+        Gets an authenticated Secrets Manager client.
+
+        Returns:
+            An authenticated Secrets Manager client.
+        """
+        return self.get_client(client_type=ClientType.SECRETS_MANAGER)
 
 
-@pytest.mark.parametrize(
-    "credentials",
-    [
-        AwsCredentials(),
-        MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
-        ),
-    ],
-)
-@pytest.mark.parametrize("client_type", ["ecs", ClientType.ECS])
-def test_credentials_get_client_ecs(credentials, client_type):
-    with mock_s3():
-        assert isinstance(credentials.get_client(client_type), BaseClient)
+class MinIOCredentials(CredentialsBlock):
+    """
+    Block used to manage authentication with MinIO. Refer to the
+    [MinIO docs](https://docs.min.io/docs/minio-server-configuration-guide.html)
+    for more info about the possible credential configurations.
 
+    Attributes:
+        minio_root_user: Admin or root user.
+        minio_root_password: Admin or root password.
+        region_name: Location of server, e.g. "us-east-1".
 
-@pytest.mark.parametrize(
-    "credentials",
-    [
-        AwsCredentials(),
-        MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
-        ),
-    ],
-)
-@pytest.mark.parametrize("client_type", ["batch", ClientType.BATCH])
-def test_credentials_get_client_batch(credentials, client_type):
-    with mock_s3():
-        assert isinstance(credentials.get_client(client_type), BaseClient)
+    Example:
+        Load stored MinIO credentials:
+        ```python
+        from prefect_aws import MinIOCredentials
 
+        minio_credentials_block = MinIOCredentials.load("BLOCK_NAME")
+        ```
+    """  # noqa E501
 
-@pytest.mark.parametrize(
-    "credentials",
-    [
-        AwsCredentials(),
-        MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
-        ),
-    ],
-)
-@pytest.mark.parametrize("client_type", ["s3", ClientType.S3])
-def test_credentials_get_client_cached_s3(credentials, client_type):
-    with mock_s3():
-        assert isinstance(_get_client_cached(credentials, client_type), BaseClient)
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/676cb17bcbdff601f97e0a02ff8bcb480e91ff40-250x250.png"  # noqa
+    _block_type_name = "MinIO Credentials"
+    _description = (
+        "Block used to manage authentication with MinIO. Refer to the MinIO "
+        "docs: https://docs.min.io/docs/minio-server-configuration-guide.html "
+        "for more info about the possible credential configurations."
+    )
+    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.MinIOCredentials"  # noqa
 
+    minio_root_user: str = Field(default=..., description="Admin or root user.")
+    minio_root_password: SecretStr = Field(
+        default=..., description="Admin or root password."
+    )
+    region_name: Optional[str] = Field(
+        default=None,
+        description="The AWS Region where you want to create new connections.",
+    )
+    aws_client_parameters: AwsClientParameters = Field(
+        default_factory=AwsClientParameters,
+        description="Extra parameters to initialize the Client.",
+    )
 
-@pytest.mark.parametrize(
-    "credentials",
-    [
-        AwsCredentials(),
-        MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
-        ),
-    ],
-)
-@pytest.mark.parametrize("client_type", ["ecs", ClientType.ECS])
-def test_credentials_get_client_cached_ecs(credentials, client_type):
-    with mock_s3():
-        client = _get_client_cached(credentials, client_type)
+    def get_boto3_session(self) -> boto3.Session:
+        """
+        Returns an authenticated boto3 session that can be used to create clients
+        and perform object operations on MinIO server.
 
-        assert isinstance(client, BaseClient)
+        Example:
+            Create an S3 client from an authorized boto3 session
+
+            ```python
+            minio_credentials = MinIOCredentials(
+                minio_root_user = "minio_root_user",
+                minio_root_password = "minio_root_password"
+            )
+            s3_client = minio_credentials.get_boto3_session().client(
+                service="s3",
+                endpoint_url="http://localhost:9000"
+            )
+            ```
+        """
+
+        minio_root_password = (
+            self.minio_root_password.get_secret_value()
+            if self.minio_root_password
+            else None
+        )
+
+        return boto3.Session(
+            aws_access_key_id=self.minio_root_user,
+            aws_secret_access_key=minio_root_password,
+            region_name=self.region_name,
+        )
+
+    def get_client(self, client_type: Union[str, ClientType]) -> Any:
+        """
+        Helper method to dynamically get a client type.
+
+        Args:
+            client_type: The client's service name.
+
+        Returns:
+            An authenticated client.
+
+        Raises:
+            ValueError: if the client is not supported.
+        """
+        if isinstance(client_type, ClientType):
+            client_type = client_type.value
+
+        client = self.get_boto3_session().client(
+            service_name=client_type, **self.aws_client_parameters.get_params_override()
+        )
+        return client
+
+    def get_s3_client(self) -> S3Client:
+        """
+        Gets an authenticated S3 client.
+
+        Returns:
+            An authenticated S3 client.
+        """
+        return self.get_client(client_type=ClientType.S3)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -73,11 +73,3 @@ def test_get_client_cached():
     # Verify that _get_client_cached is called only once due to caching
     assert _get_client_cached.cache_info().misses == 1
     assert _get_client_cached.cache_info().hits == 2
-
-    # Test with different parameters to ensure they are cached separately
-    aws_credentials_block.get_client(ClientType.SECRETS_MANAGER)
-    aws_credentials_block.get_client(ClientType.SECRETS_MANAGER)
-
-    # "Should be called again with different parameters"
-    assert _get_client_cached.cache_info().misses == 2
-    assert _get_client_cached.cache_info().hits == 3

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,249 +1,46 @@
-"""Module handling AWS credentials"""
+import pytest
+from boto3.session import Session
+from botocore.client import BaseClient
+from moto import mock_s3
 
-from enum import Enum
-from typing import Any, Optional, Union
-
-import boto3
-from mypy_boto3_s3 import S3Client
-from mypy_boto3_secretsmanager import SecretsManagerClient
-from prefect.blocks.abstract import CredentialsBlock
-from pydantic import VERSION as PYDANTIC_VERSION
-
-if PYDANTIC_VERSION.startswith("2."):
-    from pydantic.v1 import Field, SecretStr
-else:
-    from pydantic import Field, SecretStr
-
-from prefect_aws.client_parameters import AwsClientParameters
+from prefect_aws.credentials import AwsCredentials, ClientType, MinIOCredentials
 
 
-class ClientType(Enum):
-    S3 = "s3"
-    ECS = "ecs"
-    BATCH = "batch"
-    SECRETS_MANAGER = "secretsmanager"
-
-
-class AwsCredentials(CredentialsBlock):
+def test_aws_credentials_get_boto3_session():
     """
-    Block used to manage authentication with AWS. AWS authentication is
-    handled via the `boto3` module. Refer to the
-    [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
-    for more info about the possible credential configurations.
+    Asserts that instantiated AwsCredentials block creates an
+    authenticated boto3 session.
+    """
 
-    Example:
-        Load stored AWS credentials:
-        ```python
-        from prefect_aws import AwsCredentials
+    with mock_s3():
+        aws_credentials_block = AwsCredentials()
+        boto3_session = aws_credentials_block.get_boto3_session()
+        assert isinstance(boto3_session, Session)
 
-        aws_credentials_block = AwsCredentials.load("BLOCK_NAME")
-        ```
-    """  # noqa E501
 
-    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/d74b16fe84ce626345adf235a47008fea2869a60-225x225.png"  # noqa
-    _block_type_name = "AWS Credentials"
-    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.AwsCredentials"  # noqa
+def test_minio_credentials_get_boto3_session():
+    """
+    Asserts that instantiated MinIOCredentials block creates
+    an authenticated boto3 session.
+    """
 
-    aws_access_key_id: Optional[str] = Field(
-        default=None,
-        description="A specific AWS access key ID.",
-        title="AWS Access Key ID",
+    minio_credentials_block = MinIOCredentials(
+        minio_root_user="root_user", minio_root_password="root_password"
     )
-    aws_secret_access_key: Optional[SecretStr] = Field(
-        default=None,
-        description="A specific AWS secret access key.",
-        title="AWS Access Key Secret",
-    )
-    aws_session_token: Optional[str] = Field(
-        default=None,
-        description=(
-            "The session key for your AWS account. "
-            "This is only needed when you are using temporary credentials."
+    boto3_session = minio_credentials_block.get_boto3_session()
+    assert isinstance(boto3_session, Session)
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        AwsCredentials(),
+        MinIOCredentials(
+            minio_root_user="root_user", minio_root_password="root_password"
         ),
-        title="AWS Session Token",
-    )
-    profile_name: Optional[str] = Field(
-        default=None, description="The profile to use when creating your session."
-    )
-    region_name: Optional[str] = Field(
-        default=None,
-        description="The AWS Region where you want to create new connections.",
-    )
-    aws_client_parameters: AwsClientParameters = Field(
-        default_factory=AwsClientParameters,
-        description="Extra parameters to initialize the Client.",
-        title="AWS Client Parameters",
-    )
-
-    def get_boto3_session(self) -> boto3.Session:
-        """
-        Returns an authenticated boto3 session that can be used to create clients
-        for AWS services
-
-        Example:
-            Create an S3 client from an authorized boto3 session:
-            ```python
-            aws_credentials = AwsCredentials(
-                aws_access_key_id = "access_key_id",
-                aws_secret_access_key = "secret_access_key"
-                )
-            s3_client = aws_credentials.get_boto3_session().client("s3")
-            ```
-        """
-
-        if self.aws_secret_access_key:
-            aws_secret_access_key = self.aws_secret_access_key.get_secret_value()
-        else:
-            aws_secret_access_key = None
-
-        return boto3.Session(
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=self.aws_session_token,
-            profile_name=self.profile_name,
-            region_name=self.region_name,
-        )
-
-    def get_client(self, client_type: Union[str, ClientType]) -> Any:
-        """
-        Helper method to dynamically get a client type.
-
-        Args:
-            client_type: The client's service name.
-
-        Returns:
-            An authenticated client.
-
-        Raises:
-            ValueError: if the client is not supported.
-        """
-        if isinstance(client_type, ClientType):
-            client_type = client_type.value
-
-        client = self.get_boto3_session().client(
-            service_name=client_type, **self.aws_client_parameters.get_params_override()
-        )
-        return client
-
-    def get_s3_client(self) -> S3Client:
-        """
-        Gets an authenticated S3 client.
-
-        Returns:
-            An authenticated S3 client.
-        """
-        return self.get_client(client_type=ClientType.S3)
-
-    def get_secrets_manager_client(self) -> SecretsManagerClient:
-        """
-        Gets an authenticated Secrets Manager client.
-
-        Returns:
-            An authenticated Secrets Manager client.
-        """
-        return self.get_client(client_type=ClientType.SECRETS_MANAGER)
-
-
-class MinIOCredentials(CredentialsBlock):
-    """
-    Block used to manage authentication with MinIO. Refer to the
-    [MinIO docs](https://docs.min.io/docs/minio-server-configuration-guide.html)
-    for more info about the possible credential configurations.
-
-    Attributes:
-        minio_root_user: Admin or root user.
-        minio_root_password: Admin or root password.
-        region_name: Location of server, e.g. "us-east-1".
-
-    Example:
-        Load stored MinIO credentials:
-        ```python
-        from prefect_aws import MinIOCredentials
-
-        minio_credentials_block = MinIOCredentials.load("BLOCK_NAME")
-        ```
-    """  # noqa E501
-
-    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/676cb17bcbdff601f97e0a02ff8bcb480e91ff40-250x250.png"  # noqa
-    _block_type_name = "MinIO Credentials"
-    _description = (
-        "Block used to manage authentication with MinIO. Refer to the MinIO "
-        "docs: https://docs.min.io/docs/minio-server-configuration-guide.html "
-        "for more info about the possible credential configurations."
-    )
-    _documentation_url = "https://prefecthq.github.io/prefect-aws/credentials/#prefect_aws.credentials.MinIOCredentials"  # noqa
-
-    minio_root_user: str = Field(default=..., description="Admin or root user.")
-    minio_root_password: SecretStr = Field(
-        default=..., description="Admin or root password."
-    )
-    region_name: Optional[str] = Field(
-        default=None,
-        description="The AWS Region where you want to create new connections.",
-    )
-    aws_client_parameters: AwsClientParameters = Field(
-        default_factory=AwsClientParameters,
-        description="Extra parameters to initialize the Client.",
-    )
-
-    def get_boto3_session(self) -> boto3.Session:
-        """
-        Returns an authenticated boto3 session that can be used to create clients
-        and perform object operations on MinIO server.
-
-        Example:
-            Create an S3 client from an authorized boto3 session
-
-            ```python
-            minio_credentials = MinIOCredentials(
-                minio_root_user = "minio_root_user",
-                minio_root_password = "minio_root_password"
-            )
-            s3_client = minio_credentials.get_boto3_session().client(
-                service="s3",
-                endpoint_url="http://localhost:9000"
-            )
-            ```
-        """
-
-        minio_root_password = (
-            self.minio_root_password.get_secret_value()
-            if self.minio_root_password
-            else None
-        )
-
-        return boto3.Session(
-            aws_access_key_id=self.minio_root_user,
-            aws_secret_access_key=minio_root_password,
-            region_name=self.region_name,
-        )
-
-    def get_client(self, client_type: Union[str, ClientType]) -> Any:
-        """
-        Helper method to dynamically get a client type.
-
-        Args:
-            client_type: The client's service name.
-
-        Returns:
-            An authenticated client.
-
-        Raises:
-            ValueError: if the client is not supported.
-        """
-        if isinstance(client_type, ClientType):
-            client_type = client_type.value
-
-        client = self.get_boto3_session().client(
-            service_name=client_type, **self.aws_client_parameters.get_params_override()
-        )
-        return client
-
-    def get_s3_client(self) -> S3Client:
-        """
-        Gets an authenticated S3 client.
-
-        Returns:
-            An authenticated S3 client.
-        """
-        return self.get_client(client_type=ClientType.S3)
+    ],
+)
+@pytest.mark.parametrize("client_type", ["s3", ClientType.S3])
+def test_credentials_get_client(credentials, client_type):
+    with mock_s3():
+        assert isinstance(credentials.get_client(client_type), BaseClient)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -51,12 +51,14 @@ def test_credentials_get_client(credentials, client_type):
         assert isinstance(credentials.get_client(client_type), BaseClient)
 
 
-@pytest.mark.parametrize("credentials", [AwsCredentials()])
-def test_get_client_cached(credentials):
+def test_get_client_cached():
     """
     Test to ensure that _get_client_cached function returns the same instance
     for multiple calls with the same parameters and properly utilizes lru_cache.
     """
+
+    # Create a mock AwsCredentials instance
+    aws_credentials_block = AwsCredentials()
 
     # Clear cache
     _get_client_cached.cache_clear()
@@ -64,17 +66,17 @@ def test_get_client_cached(credentials):
     assert _get_client_cached.cache_info().hits == 0, "Initial call count should be 0"
 
     # Call get_client multiple times with the same parameters
-    credentials.get_client(ClientType.S3)
-    credentials.get_client(ClientType.S3)
-    credentials.get_client(ClientType.S3)
+    aws_credentials_block.get_client(ClientType.S3)
+    aws_credentials_block.get_client(ClientType.S3)
+    aws_credentials_block.get_client(ClientType.S3)
 
     # Verify that _get_client_cached is called only once due to caching
     assert _get_client_cached.cache_info().misses == 1
     assert _get_client_cached.cache_info().hits == 2
 
     # Test with different parameters to ensure they are cached separately
-    credentials.get_client(ClientType.ECS)
-    credentials.get_client(ClientType.ECS)
+    aws_credentials_block.get_client(ClientType.SECRETS_MANAGER)
+    aws_credentials_block.get_client(ClientType.SECRETS_MANAGER)
 
     # "Should be called again with different parameters"
     assert _get_client_cached.cache_info().misses == 2

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -59,7 +59,7 @@ def test_get_client_cached(client_type):
     """
 
     # Create a mock AwsCredentials instance
-    aws_credentials_block = AwsCredentials()
+    aws_credentials_block = AwsCredentials(region_name="us-east-1")
 
     # Clear cache
     _get_client_cached.cache_clear()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -56,7 +56,9 @@ def test_credentials_get_client(credentials, client_type):
     [
         AwsCredentials(region_name="us-east-1"),
         MinIOCredentials(
-            minio_root_user="root_user", minio_root_password="root_password"
+            minio_root_user="root_user",
+            minio_root_password="root_password",
+            region_name="us-east-1",
         ),
     ],
 )
@@ -113,7 +115,9 @@ def test_minio_credentials_change_causes_cache_miss(client_type):
     _get_client_cached.cache_clear()
 
     credentials = MinIOCredentials(
-        minio_root_user="root_user", minio_root_password="root_password"
+        minio_root_user="root_user",
+        minio_root_password="root_password",
+        region_name="us-east-1",
     )
 
     initial_client = credentials.get_client(client_type)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -12,7 +12,6 @@ from pytest_lazyfixture import lazy_fixture
 
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
-from prefect_aws.credentials import _get_client_cached
 from prefect_aws.s3 import (
     S3Bucket,
     s3_copy,
@@ -1048,16 +1047,3 @@ class TestS3Bucket:
 
         with pytest.raises(ClientError):
             assert s3_bucket_with_object.read_path("object") == b"TEST"
-
-    def test_client_is_cached_when_specified(self, aws_creds_block):
-        s3_bucket = S3Bucket(
-            bucket_name="bucket", credentials=aws_creds_block, cache_client=True
-        )
-
-        _get_client_cached.cache_clear()
-
-        s3_bucket._get_s3_client()
-        s3_bucket._get_s3_client()
-
-        assert _get_client_cached.cache_info().hits == 1
-        assert _get_client_cached.cache_info().misses == 1

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -12,6 +12,7 @@ from pytest_lazyfixture import lazy_fixture
 
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
+from prefect_aws.credentials import _get_client_cached
 from prefect_aws.s3 import (
     S3Bucket,
     s3_copy,
@@ -1047,3 +1048,16 @@ class TestS3Bucket:
 
         with pytest.raises(ClientError):
             assert s3_bucket_with_object.read_path("object") == b"TEST"
+
+    def test_client_is_cached_when_specified(self, aws_creds_block):
+        s3_bucket = S3Bucket(
+            bucket_name="bucket", credentials=aws_creds_block, cache_client=True
+        )
+
+        _get_client_cached.cache_clear()
+
+        s3_bucket._get_s3_client()
+        s3_bucket._get_s3_client()
+
+        assert _get_client_cached.cache_info().hits == 1
+        assert _get_client_cached.cache_info().misses == 1


### PR DESCRIPTION
closes #332 

This PR introduces an enhanced default caching strategy for boto client instances within our `AwsCredentials` and `MinIOCredentials` classes.

- We now cache boto client instances by default using Python's `lru_cache` mechanism, keyed on the credentials context (`ctx`) and client type.
- The cache key is derived from a comprehensive hash of the credentials object, including fields like AWS access keys, secret access keys, session tokens, profile names, and region names, along with parameters specific to each client type.
- The `__hash__` method of `AwsCredentials` and `MinIOCredentials` is based on the combination of these fields, ensuring that any changes to the credentials object results in a different hash and thus a new cache entry.
- Thread safety via a global lock (`_LOCK`), which synchronizes access to the `get_client` function, preventing race conditions in multi-threaded environments.


thanks to @mattiamatrix for doing the bulk of this work