### PR TITLE
Add ECS worker option to use most recent revision in task definition family

### DIFF
--- a/prefect_aws/workers/ecs_worker.py
+++ b/prefect_aws/workers/ecs_worker.py
@@ -268,6 +268,7 @@ class ECSJobConfiguration(BaseJobConfiguration):
     vpc_id: Optional[str] = Field(default=None)
     container_name: Optional[str] = Field(default=None)
     cluster: Optional[str] = Field(default=None)
+    match_latest_revision_in_family: bool = Field(default=False)
 
     @root_validator
     def task_run_request_requires_arn_if_no_task_definition_given(cls, values) -> dict:
@@ -551,6 +552,16 @@ class ECSVariables(BaseVariables):
             "your AWS account, instead it will be marked as INACTIVE."
         ),
     )
+    match_latest_revision_in_family: bool = Field(
+        default=False,
+        description=(
+            "If enabled, the most recent active revision in the task definition "
+            "family will be compared against the desired ECS task configuration. "
+            "If they are equal, the existing task definition will be used instead "
+            "of registering a new one. If no family is specified the default family "
+            f'"{ECS_DEFAULT_FAMILY}" will be used.'
+        ),
+    )
 
 
 class ECSWorkerResult(BaseWorkerResult):
@@ -668,11 +679,12 @@ class ECSWorker(BaseWorker):
         new_task_definition_registered = False
 
         if not task_definition_arn:
-            cached_task_definition_arn = _TASK_DEFINITION_CACHE.get(
-                flow_run.deployment_id
-            )
             task_definition = self._prepare_task_definition(
                 configuration, region=ecs_client.meta.region_name
+            )
+
+            cached_task_definition_arn = _TASK_DEFINITION_CACHE.get(
+                flow_run.deployment_id
             )
 
             if cached_task_definition_arn:
@@ -710,6 +722,31 @@ class ECSWorker(BaseWorker):
                         _TASK_DEFINITION_CACHE.pop(flow_run.deployment_id, None)
                         cached_task_definition_arn = None
 
+            # use the family as a fallback if we don't have a local cached definition
+            if (
+                configuration.match_latest_revision_in_family
+                and not cached_task_definition_arn
+            ):
+                try:
+                    task_definition_from_family = self._retrieve_task_definition(
+                        logger,
+                        ecs_client,
+                        task_definition.get("family", ECS_DEFAULT_FAMILY),
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to retrieve a definition for task family "
+                        f"{task_definition.get('family', ECS_DEFAULT_FAMILY)!r}: "
+                        f"{exc!r}"
+                    )
+                else:
+                    if self._task_definitions_equal(
+                        task_definition, task_definition_from_family
+                    ):
+                        cached_task_definition_arn = task_definition_from_family[
+                            "taskDefinitionArn"
+                        ]
+
             if not cached_task_definition_arn:
                 task_definition_arn = self._register_task_definition(
                     logger, ecs_client, task_definition
@@ -717,6 +754,7 @@ class ECSWorker(BaseWorker):
                 new_task_definition_registered = True
             else:
                 task_definition_arn = cached_task_definition_arn
+
         else:
             task_definition = self._retrieve_task_definition(
                 logger, ecs_client, task_definition_arn
@@ -938,15 +976,19 @@ class ECSWorker(BaseWorker):
         self,
         logger: logging.Logger,
         ecs_client: _ECSClient,
-        task_definition_arn: str,
+        task_definition: str,
     ):
         """
         Retrieve an existing task definition from AWS.
         """
-        logger.info(f"Retrieving ECS task definition {task_definition_arn!r}...")
-        response = ecs_client.describe_task_definition(
-            taskDefinition=task_definition_arn
-        )
+        if task_definition.startswith("arn:aws:ecs:"):
+            logger.info(f"Retrieving ECS task definition {task_definition!r}...")
+        else:
+            logger.info(
+                "Retrieving most recent active revision from "
+                f"ECS task family {task_definition!r}..."
+            )
+        response = ecs_client.describe_task_definition(taskDefinition=task_definition)
         return response["taskDefinition"]
 
     def _wait_for_task_start(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #368

Adds an option to the ECS worker for using the most recent revision in the task definition family.

Using the family name from the `family` field on either the work pool or the deployment's `job_variables` (`"prefect"` if left empty), the most recent revision of that family's task definition is retrieved and compared against the task definition constructed by the worker. If they are a match, the retrieved task definition's ARN is used rather than proceeding with registration of a new task definition. These steps are only taken if the task definition cache is empty or the cached definition fails to validate.

This approach is similar to the one implemented in [Jenkins](https://github.com/jenkinsci/amazon-ecs-plugin/blob/master/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSService.java#L171) and should reduce occurrences of task definition registration when used effectively.

It should be noted that careful `family` name management is required across deployments which share matching configuration, else new registration of task definitions not present in the worker's cache within a single family may reduce the usefulness of this option.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
A new worker with an empty cache picks up the most recent revision from the `prefect` family since the deployment's configuration matches:
```bash
Worker 'ECSWorker 03fd9887-2943-4229-ba6c-fa713727af7c' started!
22:17:19.500 | INFO    | prefect.flow_runs.worker - Worker 'ECSWorker 03fd9887-2943-4229-ba6c-fa713727af7c' submitting flow run '77ceb587-3fee-448a-bca9-96c7b47c4616'
22:17:20.273 | INFO    | prefect.flow_runs.worker - Retrieving most recent active revision from ECS task family 'prefect'...
22:17:20.409 | INFO    | prefect.flow_runs.worker - Using ECS task definition 'arn:aws:ecs:***:task-definition/prefect:29'...
22:17:20.834 | INFO    | prefect.flow_runs.worker - Creating ECS task run...
22:17:21.382 | INFO    | prefect.flow_runs.worker - Waiting for ECS task run to start...
22:17:21.438 | INFO    | prefect.flow_runs.worker - ECS task status is PROVISIONING.
22:17:31.534 | INFO    | prefect.flow_runs.worker - ECS task status is PENDING.
22:17:51.751 | INFO    | prefect.flow_runs.worker - ECS task status is RUNNING.
22:17:56.870 | INFO    | prefect.flow_runs.worker - Completed submission of flow run '77ceb587-3fee-448a-bca9-96c7b47c4616'
22:18:17.034 | INFO    | prefect.flow_runs.worker - ECS task status is DEPROVISIONING.
22:18:27.137 | INFO    | prefect.flow_runs.worker - ECS task status is STOPPED.
22:18:27.139 | INFO    | prefect.flow_runs.worker - Container 'prefect' exited successfully.
```
Upon a second run of the deployment, the in-memory cache is used instead:
```bash
22:18:40.072 | INFO    | prefect.flow_runs.worker - Worker 'ECSWorker 03fd9887-2943-4229-ba6c-fa713727af7c' submitting flow run '8932a7f5-e2bb-4ab8-bcfc-a397c3c1781e'
22:18:40.892 | INFO    | prefect.flow_runs.worker - Retrieving ECS task definition 'arn:aws:ecs:***:task-definition/prefect:29'...
22:18:41.038 | INFO    | prefect.flow_runs.worker - Using ECS task definition 'arn:aws:ecs:***:task-definition/prefect:29'...
22:18:41.359 | INFO    | prefect.flow_runs.worker - Creating ECS task run...
22:18:41.921 | INFO    | prefect.flow_runs.worker - Waiting for ECS task run to start...
22:18:41.968 | INFO    | prefect.flow_runs.worker - ECS task status is PROVISIONING.
22:18:52.059 | INFO    | prefect.flow_runs.worker - ECS task status is PENDING.
22:19:12.269 | INFO    | prefect.flow_runs.worker - ECS task status is RUNNING.
22:19:17.372 | INFO    | prefect.flow_runs.worker - Completed submission of flow run '8932a7f5-e2bb-4ab8-bcfc-a397c3c1781e'
22:19:37.536 | INFO    | prefect.flow_runs.worker - ECS task status is DEPROVISIONING.
22:19:52.690 | INFO    | prefect.flow_runs.worker - ECS task status is STOPPED.
22:19:52.691 | INFO    | prefect.flow_runs.worker - Container 'prefect' exited successfully.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-aws/blob/main/CHANGELOG.md)
