### PR TITLE
Fix `S3Bucket.copy_object` target path resolution

### DIFF
--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -1234,17 +1234,21 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """
         s3_client = self.credentials.get_s3_client()
 
-        source_path = self._resolve_path(Path(from_path).as_posix())
-        target_path = self._resolve_path(Path(to_path).as_posix())
-
         source_bucket_name = self.bucket_name
-        target_bucket_name = self.bucket_name
+        source_path = self._resolve_path(Path(from_path).as_posix())
+
+        # Use given to_bucket or self otherwise
+        to_bucket = to_bucket or self
+
+        target_bucket_name: str
+        target_path: str
         if isinstance(to_bucket, S3Bucket):
             target_bucket_name = to_bucket.bucket_name
-            target_path = to_bucket._resolve_path(target_path)
+            target_path = to_bucket._resolve_path(Path(to_path).as_posix())
         elif isinstance(to_bucket, str):
             target_bucket_name = to_bucket
-        elif to_bucket is not None:
+            target_path = Path(to_path).as_posix()
+        else:
             raise TypeError(
                 "to_bucket must be a string or S3Bucket, not"
                 f" {type(target_bucket_name)}"

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -1237,7 +1237,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         source_bucket_name = self.bucket_name
         source_path = self._resolve_path(Path(from_path).as_posix())
 
-        # Use given to_bucket or self otherwise
+        # Default to copying within the same bucket
         to_bucket = to_bucket or self
 
         target_bucket_name: str
@@ -1250,8 +1250,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             target_path = Path(to_path).as_posix()
         else:
             raise TypeError(
-                "to_bucket must be a string or S3Bucket, not"
-                f" {type(target_bucket_name)}"
+                f"to_bucket must be a string or S3Bucket, not {type(to_bucket)}"
             )
 
         self.logger.info(

--- a/prefect_aws/s3.py
+++ b/prefect_aws/s3.py
@@ -1319,20 +1319,23 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """
         s3_client = self.credentials.get_s3_client()
 
-        source_path = self._resolve_path(Path(from_path).as_posix())
-        target_path = self._resolve_path(Path(to_path).as_posix())
-
         source_bucket_name = self.bucket_name
-        target_bucket_name = self.bucket_name
+        source_path = self._resolve_path(Path(from_path).as_posix())
+
+        # Default to moving within the same bucket
+        to_bucket = to_bucket or self
+
+        target_bucket_name: str
+        target_path: str
         if isinstance(to_bucket, S3Bucket):
             target_bucket_name = to_bucket.bucket_name
-            target_path = to_bucket._resolve_path(target_path)
+            target_path = to_bucket._resolve_path(Path(to_path).as_posix())
         elif isinstance(to_bucket, str):
             target_bucket_name = to_bucket
-        elif to_bucket is not None:
+            target_path = Path(to_path).as_posix()
+        else:
             raise TypeError(
-                "to_bucket must be a string or S3Bucket, not"
-                f" {type(target_bucket_name)}"
+                f"to_bucket must be a string or S3Bucket, not {type(to_bucket)}"
             )
 
         self.logger.info(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1004,6 +1004,21 @@ class TestS3Bucket:
         assert s3_bucket_2_empty.read_path("object_copy_4") == b"TEST"
 
     @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
+    def test_copy_object_subpaths(
+        self,
+        s3_bucket_with_object: S3Bucket,
+        s3_bucket_2_empty: S3Bucket,
+    ):
+        s3_bucket_2_empty.bucket_folder = "bucket_folder"
+        # S3Bucket for second bucket has a basepath
+        key = s3_bucket_with_object.copy_object(
+            "object",
+            "object_copy_1",
+            to_bucket=s3_bucket_2_empty,
+        )
+        assert key == "bucket_folder/object_copy_1"
+
+    @pytest.mark.parametrize("client_parameters", aws_clients[-1:], indirect=True)
     def test_move_object_within_bucket(
         self,
         s3_bucket_with_object: S3Bucket,


### PR DESCRIPTION
Closes #384

Uses other bucket's `_resolve_path` method when copying to another `S3Bucket` object. If `to_bucket` is a string, doesn't resolve. Copies to `self` when `to_bucket` is None.

### Example

```python
from prefect_aws import S3Bucket

source = S3Bucket(bucket_name="source-bucket")
target = S3Bucket(bucket_name="target-bucket", bucket_folder="subpath/")
source.copy_object("abc.txt", "copies/abc.txt", target)
# subpath/copies/abc.txt
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
