### PR TITLE
update pytest requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,8 +15,8 @@ moto >= 3.1.16, < 4.2.5
 mypy
 pillow
 pre-commit
-pytest
-pytest-asyncio
+pytest > 7, < 8
+pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 pytest-cov
 pytest-lazy-fixture
 pytest-xdist


### PR DESCRIPTION
were getting a bunch of `AttributeError: 'CallSpec2' object has no attribute 'funcargs'` errors because we were using pytest 8.0