### PR TITLE
Removes `pytest-lazy-fixture` dependency to allow `pytest` to be unpinned

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,8 @@ moto >= 3.1.16, < 4.2.5
 mypy
 pillow
 pre-commit
-pytest > 7, < 8
+pytest
 pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 pytest-cov
-pytest-lazy-fixture
 pytest-xdist
 types-boto3 >= 1.0.2

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -8,7 +8,6 @@ import boto3
 import pytest
 from botocore.response import StreamingBody
 from moto import mock_iam, mock_lambda
-from pytest_lazyfixture import lazy_fixture
 
 from prefect_aws.credentials import AwsCredentials
 from prefect_aws.lambda_function import LambdaFunction
@@ -232,8 +231,8 @@ class TestLambdaFunction:
     @pytest.mark.parametrize(
         "func_fixture,expected,handler",
         [
-            (lazy_fixture("mock_lambda_function"), {"foo": "bar"}, handler_a),
-            (lazy_fixture("add_lambda_version"), {"data": [1, 2, 3]}, handler_b),
+            ("mock_lambda_function", {"foo": "bar"}, handler_a),
+            ("add_lambda_version", {"data": [1, 2, 3]}, handler_b),
         ],
     )
     def test_invoke_lambda_qualifier(
@@ -242,7 +241,9 @@ class TestLambdaFunction:
         expected,
         lambda_function: LambdaFunction,
         mock_invoke,
+        request,
     ):
+        func_fixture = request.getfixturevalue(func_fixture)
         try:
             lambda_function.qualifier = func_fixture["Version"]
             result = lambda_function.invoke()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -8,7 +8,6 @@ from botocore.exceptions import ClientError, EndpointConnectionError
 from moto import mock_s3
 from prefect import flow
 from prefect.deployments import Deployment
-from pytest_lazyfixture import lazy_fixture
 
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
@@ -22,9 +21,9 @@ from prefect_aws.s3 import (
 )
 
 aws_clients = [
-    (lazy_fixture("aws_client_parameters_custom_endpoint")),
-    (lazy_fixture("aws_client_parameters_empty")),
-    (lazy_fixture("aws_client_parameters_public_bucket")),
+    "aws_client_parameters_custom_endpoint",
+    "aws_client_parameters_empty",
+    "aws_client_parameters_public_bucket",
 ]
 
 
@@ -38,7 +37,7 @@ def s3_mock(monkeypatch, client_parameters):
 
 @pytest.fixture
 def client_parameters(request):
-    client_parameters = request.param
+    client_parameters = request.getfixturevalue(request.param)
     return client_parameters
 
 
@@ -114,7 +113,7 @@ def a_lot_of_objects(bucket, tmp_path):
 
 @pytest.mark.parametrize(
     "client_parameters",
-    [lazy_fixture("aws_client_parameters_custom_endpoint")],
+    ["aws_client_parameters_custom_endpoint"],
     indirect=True,
 )
 async def test_s3_download_failed_with_wrong_endpoint_setup(
@@ -141,30 +140,30 @@ async def test_s3_download_failed_with_wrong_endpoint_setup(
     "client_parameters",
     [
         pytest.param(
-            lazy_fixture("aws_client_parameters_custom_endpoint"),
+            "aws_client_parameters_custom_endpoint",
             marks=pytest.mark.is_public(False),
         ),
         pytest.param(
-            lazy_fixture("aws_client_parameters_custom_endpoint"),
+            "aws_client_parameters_custom_endpoint",
             marks=pytest.mark.is_public(True),
         ),
         pytest.param(
-            lazy_fixture("aws_client_parameters_empty"),
+            "aws_client_parameters_empty",
             marks=pytest.mark.is_public(False),
         ),
         pytest.param(
-            lazy_fixture("aws_client_parameters_empty"),
+            "aws_client_parameters_empty",
             marks=pytest.mark.is_public(True),
         ),
         pytest.param(
-            lazy_fixture("aws_client_parameters_public_bucket"),
+            "aws_client_parameters_public_bucket",
             marks=[
                 pytest.mark.is_public(False),
                 pytest.mark.xfail(reason="Bucket is not a public one"),
             ],
         ),
         pytest.param(
-            lazy_fixture("aws_client_parameters_public_bucket"),
+            "aws_client_parameters_public_bucket",
             marks=pytest.mark.is_public(True),
         ),
     ],


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
