### PR TITLE
Adds porting of network configuration to generated base job templates

### DIFF
--- a/prefect_aws/utilities.py
+++ b/prefect_aws/utilities.py
@@ -1,5 +1,7 @@
 """Utilities for working with AWS services."""
 
+from typing import Dict, List, Union
+
 from prefect.utilities.collections import visit_collection
 
 
@@ -33,3 +35,82 @@ def hash_collection(collection) -> int:
         collection, visit_fn=make_hashable, return_data=True
     )
     return hash(hashable_collection)
+
+
+def ensure_path_exists(doc: Union[Dict, List], path: List[str]):
+    """
+    Ensures the path exists in the document, creating empty dictionaries or lists as
+    needed.
+
+    Args:
+        doc: The current level of the document or sub-document.
+        path: The remaining path parts to ensure exist.
+    """
+    if not path:
+        return
+    current_path = path.pop(0)
+    # Check if the next path part exists and is a digit
+    next_path_is_digit = path and path[0].isdigit()
+
+    # Determine if the current path is for an array or an object
+    if isinstance(doc, list):  # Path is for an array index
+        current_path = int(current_path)
+        # Ensure the current level of the document is a list and long enough
+
+        while len(doc) <= current_path:
+            doc.append({})
+        next_level = doc[current_path]
+    else:  # Path is for an object
+        if current_path not in doc or (
+            next_path_is_digit and not isinstance(doc.get(current_path), list)
+        ):
+            doc[current_path] = [] if next_path_is_digit else {}
+        next_level = doc[current_path]
+
+    ensure_path_exists(next_level, path)
+
+
+def assemble_document_for_patches(patches):
+    """
+    Assembles an initial document that can successfully accept the given JSON Patch
+    operations.
+
+    Args:
+        patches: A list of JSON Patch operations.
+
+    Returns:
+        An initial document structured to accept the patches.
+
+    Example:
+
+    ```python
+    patches = [
+        {"op": "replace", "path": "/name", "value": "Jane"},
+        {"op": "add", "path": "/contact/address", "value": "123 Main St"},
+        {"op": "remove", "path": "/age"}
+    ]
+
+    initial_document = assemble_document_for_patches(patches)
+
+    #output
+    {
+        "name": {},
+        "contact": {},
+        "age": {}
+    }
+    ```
+    """
+    document = {}
+
+    for patch in patches:
+        operation = patch["op"]
+        path = patch["path"].lstrip("/").split("/")
+
+        if operation == "add":
+            # Ensure all but the last element of the path exists
+            ensure_path_exists(document, path[:-1])
+        elif operation in ["remove", "replace"]:
+            # For remove adn replace, the entire path should exist
+            ensure_path_exists(document, path)
+
+    return document


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Updates `generate_work_pool_base_job_template` to include network configuration customizations when publishing an `ECSTask` as a work pool.

Adds some utilities for generating minimal documents to use with the JSON patches configured on a block.

Closes https://github.com/PrefectHQ/prefect-aws/issues/386

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
