### PR TITLE
Deprecate `ECSTask` block

### DIFF
--- a/prefect_aws/ecs.py
+++ b/prefect_aws/ecs.py
@@ -1,4 +1,11 @@
 """
+DEPRECATION WARNING:
+
+This module is deprecated as of March 2024 and will not be available after September 2024.
+It has been replaced by the ECS worker, which offers enhanced functionality and better performance.
+
+For upgrade instructions, see https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/.
+
 Integrations with the Amazon Elastic Container Service.
 
 Examples:
@@ -102,7 +109,8 @@ Examples:
         ],
     )
     ```
-"""
+"""  # noqa
+
 import copy
 import difflib
 import json
@@ -118,6 +126,7 @@ import boto3
 import yaml
 from anyio.abc import TaskStatus
 from jsonpointer import JsonPointerException
+from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.blocks.core import BlockNotSavedError
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
@@ -205,6 +214,14 @@ def _pretty_diff(d1: dict, d2: dict) -> str:
     )
 
 
+@deprecated_class(
+    start_date="Mar 2024",
+    help=(
+        "Use the ECS worker instead."
+        " Refer to the upgrade guide for more information:"
+        " https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/."
+    ),
+)
 class ECSTask(Infrastructure):
     """
     Run a command as an ECS task.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ boto3>=1.24.53
 botocore>=1.27.53
 mypy_boto3_s3>=1.24.94
 mypy_boto3_secretsmanager>=1.26.49
-prefect>=2.14.10
+prefect>=2.16.4
 tenacity>=8.0.0

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -12,6 +12,7 @@ import yaml
 from botocore.exceptions import ClientError
 from moto import mock_ec2, mock_ecs, mock_logs
 from moto.ec2.utils import generate_instance_identity_document
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.logging.configuration import setup_logging
 from prefect.server.schemas.core import Deployment, Flow, FlowRun
@@ -34,6 +35,20 @@ from prefect_aws.ecs import (
     get_prefect_container,
     parse_task_identifier,
 )
+
+
+def test_ecs_task_emits_deprecation_warning():
+    with pytest.warns(
+        PrefectDeprecationWarning,
+        match=(
+            "prefect_aws.ecs.ECSTask has been deprecated."
+            " It will not be available after Sep 2024."
+            " Use the ECS worker instead."
+            " Refer to the upgrade guide for more information"
+        ),
+    ):
+        ECSTask()
+
 
 setup_logging()
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds a deprecation warning to the `ECSTask` block. The ECS worker should be used instead.

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-aws/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
